### PR TITLE
destroy out mode, readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TypeScript Particles
 
-## tsparticles
+## tsParticles
 
 [![CodeFactor](https://www.codefactor.io/repository/github/matteobruni/tsparticles/badge)](https://www.codefactor.io/repository/github/matteobruni/tsparticles)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/b983aaf3461a4c48b1e2eecce1ff1d74)](https://www.codacy.com/manual/ar3s/tsparticles?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=matteobruni/tsparticles&amp;utm_campaign=Badge_Grade)
@@ -52,7 +52,7 @@ Load tsParticles and configure the particles:
 
 ```javascript
 /* tsParticles.load(@dom-id, @path-json, @callback (optional)); */
-tsParticles.loadJSON("tsparticles", "assets/particles.json").then(() => {
+tsParticles.loadJSON("tsparticles", "presets/default.json").then((container) => {
   console.log("callback - tsparticles config loaded");
 }).catch((error) => {
   console.error(error);
@@ -76,18 +76,18 @@ tsParticles.load("tsparticles", { /* options here */ });
 
 **particles.json**
 
-```javascript
+```json
 {
   "particles": {
+    "color": {
+      "value": "#ffffff"
+    },
     "number": {
       "value": 80,
       "density": {
         "enable": true,
         "value_area": 800
       }
-    },
-    "color": {
-      "value": "#ffffff"
     },
     "shape": {
       "type": "circle",
@@ -185,7 +185,8 @@ tsParticles.load("tsparticles", { /* options here */ });
       }
     }
   },
-  "retina_detect": true
+  "retina_detect": true,
+  "fps_limit": 60
 }
 ```
 
@@ -228,7 +229,7 @@ key | option type / notes | example
 `particles.move.direction` | string | `"none"` <br /> `"top"` <br /> `"top-right"` <br /> `"right"` <br /> `"bottom-right"` <br /> `"bottom"` <br /> `"bottom-left"` <br /> `"left"` <br /> `"top-left"`
 `particles.move.random` | boolean | `true` / `false`
 `particles.move.straight` | boolean | `true` / `false`
-`particles.move.out_mode` | string <br /> (out of canvas) | `"out"` <br /> `"bounce"` <br /> `"bounce-vertical"` <br /> `"bounce-horizontal"`
+`particles.move.out_mode` | string <br /> (out of canvas) | `"out"`<br /> `"destroy"` <br /> `"bounce"` <br /> `"bounce-vertical"` <br /> `"bounce-horizontal"`
 `particles.move.bounce` | boolean <br /> (between particles) | `true` / `false`
 `particles.move.attract.enable` | boolean | `true` / `false`
 `particles.move.attract.rotateX` | number | `3000`
@@ -249,3 +250,4 @@ key | option type / notes | example
 `interactivity.events.modes.push.particles_nb` | number | `4`
 `interactivity.events.modes.remove.particles_nb` | number | `4`
 `retina_detect` | boolean | `true` / `false`
+`fps_limit` | number | `60`

--- a/demo/index.html
+++ b/demo/index.html
@@ -62,7 +62,7 @@
     <!-- panel -->
     <div class="panel">
         <h1>tsparticles</h1>
-        <span class="r-version">v1.5.3</span>
+        <span class="r-version">v1.5.4</span>
         <h2>A lightweight TypeScript library for creating particles</h2>
         <ul>
             <li>

--- a/demo/js/gui.js
+++ b/demo/js/gui.js
@@ -264,7 +264,7 @@
             tsParticles_GUI.options.particles.move.speed = value;
             return await p.update();
         });
-        f.particles.move.add(tsParticles_GUI.options.particles.move, "out_mode", ["out", "bounce", "bounce-vertical", "bounce-horizontal"]).name("out_mode").onChange(async function(value) {
+        f.particles.move.add(tsParticles_GUI.options.particles.move, "out_mode", ["out", "destroy", "bounce", "bounce-vertical", "bounce-horizontal"]).name("out_mode").onChange(async function(value) {
             tsParticles_GUI.options.particles.move.out_mode = value;
             return await p.update();
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tsparticles",
-  "version": "1.4.10",
+  "version": "1.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tsparticles",
-    "version": "1.5.3",
+    "version": "1.5.4",
     "description": "Porting of Vincent Garreau's particles.js, converted in TypeScript.",
     "homepage": "https://github.com/matteobruni/tsparticles",
     "scripts": {

--- a/src/Classes/Particle/Updater.ts
+++ b/src/Classes/Particle/Updater.ts
@@ -4,6 +4,7 @@ import {Container} from "../Container";
 import {OutMode} from "../../Enums/OutMode";
 import {Particle} from "../Particle";
 import {Utils} from "../Utils/Utils";
+import {ClickMode} from "../../Enums/ClickMode";
 
 export class Updater {
     private readonly particle: Particle;
@@ -233,20 +234,37 @@ export class Updater {
             };
         }
 
-        if ((particle.position.x) - particle.radius > container.canvas.width - particle.offset.x) {
-            particle.position.x = newPos.x_left;
-            particle.position.y = Math.random() * container.canvas.height;
-        } else if ((particle.position.x) + particle.radius < 0 - particle.offset.x) {
-            particle.position.x = newPos.x_right;
-            particle.position.y = Math.random() * container.canvas.height;
-        }
+        if (outMode == OutMode.destroy) {
+            if (particle.position.x - particle.radius > container.canvas.width ||
+                particle.position.x + particle.radius < 0 ||
+                particle.position.y - particle.radius > container.canvas.height ||
+                particle.position.y + particle.radius < 0) {
+                const idx = container.particles.array.indexOf(particle);
+                container.particles.array.splice(idx, 1);
 
-        if ((particle.position.y) - particle.radius > container.canvas.height - particle.offset.y) {
-            particle.position.y = newPos.y_top;
-            particle.position.x = Math.random() * container.canvas.width;
-        } else if ((particle.position.y) + particle.radius < 0 - particle.offset.y) {
-            particle.position.y = newPos.y_bottom;
-            particle.position.x = Math.random() * container.canvas.width;
+                /* remove the canvas if the arary is empty */
+                const clickMode = options.interactivity.events.onclick.mode;
+
+                if (!container.particles.array.length && !Utils.isInArray(ClickMode.push, clickMode)) {
+                    container.destroy();
+                }
+            }
+        } else {
+            if ((particle.position.x) - particle.radius > container.canvas.width - particle.offset.x) {
+                particle.position.x = newPos.x_left;
+                particle.position.y = Math.random() * container.canvas.height;
+            } else if ((particle.position.x) + particle.radius < 0 - particle.offset.x) {
+                particle.position.x = newPos.x_right;
+                particle.position.y = Math.random() * container.canvas.height;
+            }
+
+            if ((particle.position.y) - particle.radius > container.canvas.height - particle.offset.y) {
+                particle.position.y = newPos.y_top;
+                particle.position.x = Math.random() * container.canvas.width;
+            } else if ((particle.position.y) + particle.radius < 0 - particle.offset.y) {
+                particle.position.y = newPos.y_bottom;
+                particle.position.x = Math.random() * container.canvas.width;
+            }
         }
     }
 

--- a/src/Classes/Particles.ts
+++ b/src/Classes/Particles.ts
@@ -33,9 +33,8 @@ export class Particles {
     public update(delta: number): void {
         const container = this.container;
         const options = container.options;
-        const arrLength = this.array.length;
 
-        for (let i = 0; i < arrLength; i++) {
+        for (let i = 0; i < this.array.length; i++) {
             /* the particle */
             const p = this.array[i];
             // let d = ( dx = container.interactivity.mouse.click_pos_x - p.x ) * dx +
@@ -51,7 +50,7 @@ export class Particles {
 
             /* interaction auto between particles */
             if (options.particles.line_linked.enable || options.particles.move.attract.enable) {
-                for (let j = i + 1; j < arrLength; j++) {
+                for (let j = i + 1; j < this.array.length; j++) {
                     const p2 = this.array[j];
 
                     p.interact(p2);

--- a/src/Enums/OutMode.ts
+++ b/src/Enums/OutMode.ts
@@ -5,4 +5,5 @@ export enum OutMode {
     bounceHorizontal = "bounce-horizontal",
     bounceVertical = "bounce-vertical",
     out = "out",
+    destroy = "destroy"
 }

--- a/src/Enums/OutMode.ts
+++ b/src/Enums/OutMode.ts
@@ -5,5 +5,5 @@ export enum OutMode {
     bounceHorizontal = "bounce-horizontal",
     bounceVertical = "bounce-vertical",
     out = "out",
-    destroy = "destroy"
+    destroy = "destroy",
 }

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -6,7 +6,7 @@
 /* Demo / Generator : https://tsparticles.matteobruni.it/demo
 /* GitHub : https://www.github.com/matteobruni/tsparticles
 /* How to use? : Check the GitHub README
-/* v1.5.3
+/* v1.5.4
 /* ----------------------------------------------- */
 import {Container} from "./Classes/Container";
 import {Loader} from "./Classes/Loader";


### PR DESCRIPTION
integrated PR https://github.com/VincentGarreau/particles.js/pull/389 from @dsusco

Fixed the canvas destroy when empty, it won't be destroyed only if the click mode contains push, because you can add particles to canvas.