### PR TITLE
Hotfix 1.17.7

### DIFF
--- a/components/angular/package.json
+++ b/components/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-particles",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "keywords": [
     "tsparticles",
     "particles.js",
@@ -63,7 +63,7 @@
     "@angular/router": "^10.0.4",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
-    "tsparticles": "^1.17.6",
+    "tsparticles": "^1.17.7",
     "zone.js": "~0.10.3"
   },
   "devDependencies": {

--- a/components/angular/projects/ng-particles/package.json
+++ b/components/angular/projects/ng-particles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-particles",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "tsParticles official Angular component",
   "homepage": "https://particles.matteobruni.it/",
   "repository": {
@@ -58,6 +58,6 @@
   "peerDependencies": {
     "@angular/common": ">=2.0.0",
     "@angular/core": ">=2.0.0",
-    "tsparticles": "^1.17.6"
+    "tsparticles": "^1.17.7"
   }
 }

--- a/components/inferno/package.json
+++ b/components/inferno/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "inferno-particles",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"description": "tsParticles official Inferno component",
 	"main": "index.js",
 	"scripts": {
@@ -57,7 +57,7 @@
 	"homepage": "https://particles.matteobruni.it/",
 	"dependencies": {
 		"lodash": "^4.17.19",
-		"tsparticles": "^1.17.6"
+		"tsparticles": "^1.17.7"
 	},
 	"peerDependencies": {
 		"inferno": "^7.0.0"

--- a/components/jquery/package.json
+++ b/components/jquery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-particles",
-  "version": "1.17.6",
+  "version": "1.17.7",
   "description": "tsParticles official jQuery plugin",
   "main": "dist/jquery.particles.min.js",
   "scripts": {
@@ -73,7 +73,7 @@
   "dependencies": {
     "jquery": "^3.5.1",
     "tslib": "^2.0.0",
-    "tsparticles": "^1.17.6"
+    "tsparticles": "^1.17.7"
   },
   "devDependencies": {
     "@types/jquery": "^3.5.0",

--- a/components/preact/package.json
+++ b/components/preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preact-particles",
-  "version": "1.17.6",
+  "version": "1.17.7",
   "description": "tsParticles official Preact component",
   "main": "index.js",
   "unpkg": "umd/particles.js",
@@ -89,7 +89,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.19",
-    "tsparticles": "^1.17.6"
+    "tsparticles": "^1.17.7"
   },
   "peerDependencies": {
     "preact": "^10.0.0"

--- a/components/react/package.json
+++ b/components/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tsparticles",
-  "version": "1.17.6",
+  "version": "1.17.7",
   "description": "tsParticles official React component",
   "main": "index.js",
   "unpkg": "umd/particles.js",
@@ -93,7 +93,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.19",
-    "tsparticles": "^1.17.6"
+    "tsparticles": "^1.17.7"
   },
   "peerDependencies": {
     "react": "^16.0.0"

--- a/components/svelte/package.json
+++ b/components/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-particles",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "scripts": {
     "build": "prettier --write ./README.md && rollup -c"
   },
@@ -63,7 +63,7 @@
     "svelte": "^3.24.0"
   },
   "dependencies": {
-    "tsparticles": "^1.17.6"
+    "tsparticles": "^1.17.7"
   },
   "bugs": {
     "url": "https://github.com/matteobruni/tsparticles/issues"

--- a/components/vue/package.json
+++ b/components/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "particles.vue",
   "description": "tsParticles official Vue plugin.",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "scripts": {
     "clean": "rm -rf dist/*",
     "build": "npm run clean && yarn rollup --config rollup.config.js",
@@ -67,7 +67,7 @@
     "url": "https://github.com/sponsors/matteobruni"
   },
   "dependencies": {
-    "tsparticles": "^1.17.6",
+    "tsparticles": "^1.17.7",
     "vue": "^2.6.11",
     "vue-class-component": "^7.2.3",
     "vue-property-decorator": "^9.0.0"

--- a/core/editor/package.json
+++ b/core/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsparticles-editor",
-  "version": "1.0.0-alpha.30",
+  "version": "1.0.0-1.0.0-alpha.37.0",
   "private": true,
   "description": "tsParticles Configuration Editor",
   "keywords": [
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "tslib": "^2.0.0",
-    "tsparticles": "^1.17.6"
+    "tsparticles": "^1.17.7"
   },
   "devDependencies": {
     "@babel/core": "^7.10.5",

--- a/core/main/package.json
+++ b/core/main/package.json
@@ -4,7 +4,7 @@
     "./dist/index.js",
     "./dist/tsparticles.js"
   ],
-  "version": "1.17.6",
+  "version": "1.17.7",
   "description": "Particles.js rewritten in TypeScript (100% compatible), dependency free, improved with many new features and various bugs fixed. Browser ready and with official React/Vue/Angular/jQuery/Preact components.",
   "homepage": "https://particles.matteobruni.it/",
   "scripts": {

--- a/core/main/schema/options.schema.json
+++ b/core/main/schema/options.schema.json
@@ -577,6 +577,9 @@
     },
     "IGrabLinks": {
       "properties": {
+        "blink": {
+          "type": "boolean"
+        },
         "color": {
           "anyOf": [
             {
@@ -586,6 +589,9 @@
               "type": "string"
             }
           ]
+        },
+        "consent": {
+          "type": "boolean"
         },
         "opacity": {
           "type": "number"

--- a/core/main/src/Core/Canvas.ts
+++ b/core/main/src/Core/Canvas.ts
@@ -259,8 +259,8 @@ export class Canvas {
             if (linkColor === Constants.randomColorValue) {
                 colorLine = ColorUtils.getRandomRgbColor();
             } else if (linkColor === "mid") {
-                const sourceColor = p1.getFillColor();
-                const destColor = p2.getFillColor();
+                const sourceColor = p1.getFillColor() ?? p1.getStrokeColor();
+                const destColor = p2.getFillColor() ?? p2.getStrokeColor();
 
                 if (sourceColor && destColor) {
                     colorLine = ColorUtils.mix(sourceColor, destColor, p1.size.value, p2.size.value);

--- a/core/main/src/Core/Container.ts
+++ b/core/main/src/Core/Container.ts
@@ -33,7 +33,7 @@ export class Container {
     public attract: IAttract;
     public lastFrameTime: number;
     public pageHidden: boolean;
-    public drawer?: FrameManager;
+    public drawer: FrameManager;
     public started: boolean;
     public destroyed: boolean;
     public density: number;
@@ -171,7 +171,7 @@ export class Container {
      * Draws a frame
      */
     public draw(): void {
-        this.drawAnimationFrame = Utils.animate((t) => this.drawer?.nextFrame(t));
+        this.drawAnimationFrame = Utils.animate((t) => this.drawer.nextFrame(t));
     }
 
     /**
@@ -251,17 +251,6 @@ export class Container {
 
         this.canvas.destroy();
 
-        delete this.interactivity;
-        delete this.options;
-        delete this.retina;
-        delete this.canvas;
-        delete this.particles;
-        delete this.bubble;
-        delete this.repulse;
-        delete this.attract;
-        delete this.drawer;
-        delete this.eventListeners;
-
         for (const [, drawer] of this.drawers) {
             if (drawer.destroy) {
                 drawer.destroy(this);
@@ -327,6 +316,7 @@ export class Container {
         this.plugins = new Map<string, IContainerPlugin>();
         this.particles.linksColors = new Map<string, IRgb | string | undefined>();
 
+        delete this.particles.grabLineColor;
         delete this.particles.linksColor;
     }
 

--- a/core/main/src/Core/Particle/Interactions/Mouse/Grabber.ts
+++ b/core/main/src/Core/Particle/Interactions/Mouse/Grabber.ts
@@ -65,17 +65,38 @@ export class Grabber implements IExternalInteractor {
                         const optColor = grabLineOptions.color ?? particle.particlesOptions.links.color;
 
                         if (!container.particles.grabLineColor) {
-                            container.particles.grabLineColor =
-                                optColor === Constants.randomColorValue ||
-                                (optColor as IColor)?.value === Constants.randomColorValue
-                                    ? Constants.randomColorValue
-                                    : ColorUtils.colorToRgb(optColor);
+                            const linksOptions = container.options.interactivity.modes.grab.links;
+                            const color = typeof optColor === "string" ? optColor : optColor.value;
+
+                            /* particles.line_linked - convert hex colors to rgb */
+                            //  check for the color profile requested and
+                            //  then return appropriate value
+
+                            if (color === Constants.randomColorValue) {
+                                if (linksOptions.consent) {
+                                    container.particles.grabLineColor = ColorUtils.colorToRgb({
+                                        value: color,
+                                    });
+                                } else if (linksOptions.blink) {
+                                    container.particles.grabLineColor = Constants.randomColorValue;
+                                } else {
+                                    container.particles.grabLineColor = Constants.midColorValue;
+                                }
+                            } else if (color !== undefined) {
+                                container.particles.grabLineColor = ColorUtils.colorToRgb({
+                                    value: color,
+                                });
+                            }
                         }
 
-                        let colorLine: IRgb;
+                        let colorLine: IRgb | undefined;
 
                         if (container.particles.grabLineColor === Constants.randomColorValue) {
                             colorLine = ColorUtils.getRandomRgbColor();
+                        } else if (container.particles.grabLineColor === "mid") {
+                            const sourceColor = particle.getFillColor() ?? particle.getStrokeColor();
+
+                            colorLine = sourceColor ? ColorUtils.hslToRgb(sourceColor) : undefined;
                         } else {
                             colorLine = container.particles.grabLineColor as IRgb;
                         }

--- a/core/main/src/Core/Particle/Interactions/Mouse/Grabber.ts
+++ b/core/main/src/Core/Particle/Interactions/Mouse/Grabber.ts
@@ -1,7 +1,6 @@
 import type { Container } from "../../../Container";
 import { Constants, Utils, Circle, ColorUtils } from "../../../../Utils";
 import { IRgb } from "../../../Interfaces/IRgb";
-import { IColor } from "../../../Interfaces/IColor";
 import { HoverMode } from "../../../../Enums/Modes";
 import { IExternalInteractor } from "../../../Interfaces/IExternalInteractor";
 
@@ -9,7 +8,8 @@ import { IExternalInteractor } from "../../../Interfaces/IExternalInteractor";
  * Particle grab manager
  */
 export class Grabber implements IExternalInteractor {
-    constructor(private readonly container: Container) {}
+    constructor(private readonly container: Container) {
+    }
 
     public isEnabled(): boolean {
         const container = this.container;

--- a/core/main/src/Options/Classes/Interactivity/Modes/GrabLinks.ts
+++ b/core/main/src/Options/Classes/Interactivity/Modes/GrabLinks.ts
@@ -4,10 +4,14 @@ import { OptionsColor } from "../../OptionsColor";
 import type { IOptionLoader } from "../../../Interfaces/IOptionLoader";
 
 export class GrabLinks implements IGrabLinks, IOptionLoader<IGrabLinks> {
-    public opacity: number;
+    public blink: boolean;
     public color?: OptionsColor;
+    public consent: boolean;
+    public opacity: number;
 
     constructor() {
+        this.blink = false;
+        this.consent = false;
         this.opacity = 1;
     }
 
@@ -16,12 +20,20 @@ export class GrabLinks implements IGrabLinks, IOptionLoader<IGrabLinks> {
             return;
         }
 
-        if (data.opacity !== undefined) {
-            this.opacity = data.opacity;
+        if (data.blink !== undefined) {
+            this.blink = data.blink;
         }
 
         if (data.color !== undefined) {
             this.color = OptionsColor.create(this.color, data.color);
+        }
+
+        if (data.consent !== undefined) {
+            this.consent = data.consent;
+        }
+
+        if (data.opacity !== undefined) {
+            this.opacity = data.opacity;
         }
     }
 }

--- a/core/main/src/Options/Interfaces/Interactivity/Modes/IGrabLinks.ts
+++ b/core/main/src/Options/Interfaces/Interactivity/Modes/IGrabLinks.ts
@@ -1,6 +1,8 @@
 import type { IColor } from "../../../../Core/Interfaces/IColor";
 
 export interface IGrabLinks {
-    opacity: number;
+    blink: boolean;
     color?: string | IColor;
+    consent: boolean;
+    opacity: number;
 }

--- a/core/main/tsParticles.nuspec
+++ b/core/main/tsParticles.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>tsParticles</id>
-    <version>1.17.6</version>
+    <version>1.17.7</version>
     <title>tsparticles</title>
     <authors>Matteo Bruni</authors>
     <owners>Matteo Bruni</owners>

--- a/demo/angular/package.json
+++ b/demo/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-particles-demo",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -23,10 +23,10 @@
     "@angular/platform-browser": "~10.0.4",
     "@angular/platform-browser-dynamic": "~10.0.4",
     "@angular/router": "~10.0.4",
-    "ng-particles": "^2.0.6",
+    "ng-particles": "^2.0.7",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
-    "tsparticles": "^1.17.6",
+    "tsparticles": "^1.17.7",
     "zone.js": "^0.10.3"
   },
   "bugs": {

--- a/demo/editor/package.json
+++ b/demo/editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "editor-demo",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-1.0.0-alpha.38.0",
   "description": "> TODO: description",
   "author": "Matteo Bruni <ar3s@icloud.com>",
   "homepage": "https://github.com/matteobruni/tsparticles#readme",
@@ -35,6 +35,6 @@
     "three": "^0.118.3"
   },
   "dependencies": {
-    "tsparticles-editor": "^1.0.0-alpha.30"
+    "tsparticles-editor": "^1.0.0-1.0.0-alpha.37.0"
   }
 }

--- a/demo/inferno/package.json
+++ b/demo/inferno/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "inferno-particles-demo",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"private": true,
 	"description": "> TODO: description",
 	"main": "index.js",
@@ -17,8 +17,8 @@
 	"license": "MIT",
 	"dependencies": {
 		"inferno": "^7.4.2",
-		"inferno-particles": "^1.0.5",
-		"tsparticles": "^1.17.6"
+		"inferno-particles": "^1.0.6",
+		"tsparticles": "^1.17.7"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.10.5",

--- a/demo/jquery/package.json
+++ b/demo/jquery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jquery-particles-demo",
   "private": true,
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "> TODO: description",
   "author": "Matteo Bruni <ar3s@icloud.com>",
   "homepage": "https://github.com/matteobruni/tsparticles#readme",
@@ -21,9 +21,9 @@
   },
   "dependencies": {
     "jquery": "^3.5.1",
-    "jquery-particles": "^1.17.6",
-    "tsparticles": "^1.17.6",
-    "tsparticles-preset-basic": "^1.2.6"
+    "jquery-particles": "^1.17.7",
+    "tsparticles": "^1.17.7",
+    "tsparticles-preset-basic": "^1.2.7"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^5.13.1",

--- a/demo/main/package.json
+++ b/demo/main/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tsparticles-demo",
   "private": true,
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "> TODO: description",
   "author": "Matteo Bruni <ar3s@icloud.com>",
   "homepage": "https://github.com/matteobruni/tsparticles#readme",
@@ -40,9 +40,9 @@
     "pug-cli": "^1.0.0-alpha6",
     "stylus": "^0.54.7",
     "three": "^0.118.3",
-    "tsparticles": "^1.17.6"
+    "tsparticles": "^1.17.7"
   },
   "dependencies": {
-    "tsparticles-preset-basic": "^1.2.6"
+    "tsparticles-preset-basic": "^1.2.7"
   }
 }

--- a/demo/main/public/presets/grabRandomColor.json
+++ b/demo/main/public/presets/grabRandomColor.json
@@ -1,0 +1,120 @@
+{
+  "fpsLimit": 60,
+  "particles": {
+    "number": {
+      "value": 80,
+      "density": {
+        "enable": true,
+        "value_area": 800
+      }
+    },
+    "color": {
+      "value": "#ff0000",
+      "animation": {
+        "enable": true,
+        "speed": 20,
+        "sync": true
+      }
+    },
+    "shape": {
+      "type": "circle",
+      "stroke": {
+        "width": 0
+      },
+      "polygon": {
+        "nb_sides": 5
+      },
+      "image": {
+        "src": "https://cdn.matteobruni.it/images/particles/github.svg",
+        "width": 100,
+        "height": 100
+      }
+    },
+    "opacity": {
+      "value": 0.5,
+      "random": false,
+      "anim": {
+        "enable": false,
+        "speed": 3,
+        "opacity_min": 0.1,
+        "sync": false
+      }
+    },
+    "size": {
+      "value": 3,
+      "random": true,
+      "anim": {
+        "enable": false,
+        "speed": 20,
+        "size_min": 0.1,
+        "sync": false
+      }
+    },
+    "line_linked": {
+      "enable": true,
+      "distance": 100,
+      "color": "#ffffff",
+      "opacity": 0.4,
+      "width": 1
+    },
+    "move": {
+      "enable": true,
+      "speed": 6,
+      "direction": "none",
+      "random": false,
+      "straight": false,
+      "out_mode": "out",
+      "attract": {
+        "enable": false,
+        "rotateX": 600,
+        "rotateY": 1200
+      }
+    }
+  },
+  "interactivity": {
+    "detect_on": "canvas",
+    "events": {
+      "onhover": {
+        "enable": true,
+        "mode": "grab"
+      },
+      "onclick": {
+        "enable": true,
+        "mode": "push"
+      },
+      "resize": true
+    },
+    "modes": {
+      "grab": {
+        "distance": 400,
+        "line_linked": {
+          "color": "random",
+          "opacity": 1
+        }
+      },
+      "bubble": {
+        "distance": 400,
+        "size": 40,
+        "duration": 2,
+        "opacity": 0.8
+      },
+      "repulse": {
+        "distance": 200
+      },
+      "push": {
+        "particles_nb": 4
+      },
+      "remove": {
+        "particles_nb": 2
+      }
+    }
+  },
+  "retina_detect": true,
+  "background": {
+    "color": "#000000",
+    "image": "",
+    "position": "50% 50%",
+    "repeat": "no-repeat",
+    "size": "cover"
+  }
+}

--- a/demo/main/views/index.pug
+++ b/demo/main/views/index.pug
@@ -52,6 +52,7 @@ html(lang="en")
                                     option(value="emitterAngled") Emitter Angled
                                     option(value="emitterAbsorber") Emitter and Absorber
                                     option(value="forward") Forward
+                                    option(value="grabRandomColor") Grab Random Color
                                     option(value="growing") Growing
                                     option(value="fontawesome") Font Awesome
                                     option(value="hollowknight") Hollow Knight

--- a/demo/preact/package.json
+++ b/demo/preact/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact-particles-demo",
   "private": true,
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "> TODO: description",
   "author": "Matteo Bruni <ar3s@icloud.com>",
   "homepage": "https://github.com/matteobruni/tsparticles#readme",
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "preact": "^10.4.6",
-    "preact-particles": "^1.17.6",
+    "preact-particles": "^1.17.7",
     "preact-render-to-string": "^5.1.9",
     "preact-router": "^3.2.1"
   }

--- a/demo/react/package.json
+++ b/demo/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-tsparticles-demo",
   "private": true,
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "> TODO: description",
   "author": "Matteo Bruni <ar3s@icloud.com>",
   "homepage": "https://github.com/matteobruni/tsparticles#readme",
@@ -35,6 +35,6 @@
   "dependencies": {
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-tsparticles": "^1.17.6"
+    "react-tsparticles": "^1.17.7"
   }
 }

--- a/demo/svelte/package.json
+++ b/demo/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-demo",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "scripts": {
     "build": "rollup -c",
@@ -19,6 +19,6 @@
   },
   "dependencies": {
     "sirv-cli": "^1.0.3",
-    "svelte-particles": "^1.0.6"
+    "svelte-particles": "^1.0.7"
   }
 }

--- a/demo/vue/package.json
+++ b/demo/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "particles.vue-demo",
   "private": true,
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "VueJS Demo",
   "author": "Matteo Bruni <ar3s@icloud.com>",
   "homepage": "https://github.com/matteobruni/tsparticles#readme",
@@ -20,8 +20,8 @@
     "url": "https://github.com/matteobruni/tsparticles/issues"
   },
   "dependencies": {
-    "particles.vue": "^2.0.6",
-    "tsparticles": "^1.17.6",
+    "particles.vue": "^2.0.7",
+    "tsparticles": "^1.17.7",
     "vue": "^2.6.11",
     "vue-class-component": "^7.2.3",
     "vue-property-decorator": "^9.0.0"

--- a/presets/60fps/package.json
+++ b/presets/60fps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsparticles-preset-60fps",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "tsParticles 60fps preset",
   "homepage": "https://particles.matteobruni.it/",
   "scripts": {
@@ -64,6 +64,6 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "tsparticles": "^1.17.6"
+    "tsparticles": "^1.17.7"
   }
 }

--- a/presets/backgroundMask/package.json
+++ b/presets/backgroundMask/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsparticles-preset-background-mask",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "tsParticles backgroundMask preset",
   "homepage": "https://particles.matteobruni.it/",
   "scripts": {
@@ -64,6 +64,6 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "tsparticles": "^1.17.6"
+    "tsparticles": "^1.17.7"
   }
 }

--- a/presets/basic/package.json
+++ b/presets/basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsparticles-preset-basic",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "tsParticles basic preset",
   "homepage": "https://particles.matteobruni.it/",
   "scripts": {
@@ -64,6 +64,6 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "tsparticles": "^1.17.6"
+    "tsparticles": "^1.17.7"
   }
 }

--- a/presets/bouncing/package.json
+++ b/presets/bouncing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsparticles-preset-bouncing",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "tsParticles bouncing preset",
   "homepage": "https://particles.matteobruni.it/",
   "scripts": {
@@ -64,6 +64,6 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "tsparticles": "^1.17.6"
+    "tsparticles": "^1.17.7"
   }
 }

--- a/presets/fire/package.json
+++ b/presets/fire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsparticles-preset-fire",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "tsParticles fire preset",
   "homepage": "https://particles.matteobruni.it/",
   "scripts": {
@@ -64,6 +64,6 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "tsparticles": "^1.17.6"
+    "tsparticles": "^1.17.7"
   }
 }

--- a/presets/fontAwesome/package.json
+++ b/presets/fontAwesome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsparticles-preset-font-awesome",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "tsParticles fontAwesome preset",
   "homepage": "https://particles.matteobruni.it/",
   "scripts": {
@@ -64,6 +64,6 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "tsparticles": "^1.17.6"
+    "tsparticles": "^1.17.7"
   }
 }

--- a/presets/snow/package.json
+++ b/presets/snow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsparticles-preset-snow",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "tsParticles snow preset",
   "homepage": "https://particles.matteobruni.it/",
   "scripts": {
@@ -64,6 +64,6 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "tsparticles": "^1.17.6"
+    "tsparticles": "^1.17.7"
   }
 }

--- a/presets/stars/package.json
+++ b/presets/stars/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsparticles-preset-stars",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "tsParticles stars preset",
   "homepage": "https://particles.matteobruni.it/",
   "scripts": {
@@ -64,6 +64,6 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "tsparticles": "^1.17.6"
+    "tsparticles": "^1.17.7"
   }
 }

--- a/shapes/bubble/package.json
+++ b/shapes/bubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsparticles-shape-bubble",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "tsParticles bubble shape",
   "homepage": "https://particles.matteobruni.it/",
   "scripts": {
@@ -64,6 +64,6 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "tsparticles": "^1.17.6"
+    "tsparticles": "^1.17.7"
   }
 }

--- a/shapes/heart/package.json
+++ b/shapes/heart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsparticles-shape-heart",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "tsParticles heart shape",
   "homepage": "https://particles.matteobruni.it/",
   "scripts": {
@@ -64,6 +64,6 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "tsparticles": "^1.17.6"
+    "tsparticles": "^1.17.7"
   }
 }

--- a/shapes/multiline-text/package.json
+++ b/shapes/multiline-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsparticles-shape-multiline-text",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "tsParticles multiline text shape",
   "homepage": "https://particles.matteobruni.it/",
   "scripts": {
@@ -64,6 +64,6 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "tsparticles": "^1.17.6"
+    "tsparticles": "^1.17.7"
   }
 }

--- a/shapes/spiral/package.json
+++ b/shapes/spiral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsparticles-shape-spiral",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "tsParticles spiral shape",
   "homepage": "https://particles.matteobruni.it/",
   "scripts": {
@@ -64,6 +64,6 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "tsparticles": "^1.17.6"
+    "tsparticles": "^1.17.7"
   }
 }

--- a/templates/react-ts/package.json
+++ b/templates/react-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cra-template-particles-typescript",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Official TypeScript React tsParticles template",
   "keywords": [
     "tsparticles",
@@ -62,7 +62,7 @@
     "url": "https://github.com/matteobruni/tsparticles/issues"
   },
   "dependencies": {
-    "react-tsparticles": "^1.17.6"
+    "react-tsparticles": "^1.17.7"
   },
   "scripts": {
     "build": "node scripts/prebuild.js",

--- a/templates/react-ts/template.json
+++ b/templates/react-ts/template.json
@@ -8,7 +8,7 @@
       "@types/react": "^16.9.0",
       "@types/react-dom": "^16.9.0",
       "@types/jest": "^25.0.0",
-      "react-tsparticles": "^1.17.6",
+      "react-tsparticles": "^1.17.7",
       "typescript": "^3.9.6",
       "web-vitals": "^0.2.2"
     }

--- a/templates/react/package.json
+++ b/templates/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cra-template-particles",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Official React tsParticles template",
   "keywords": [
     "tsparticles",
@@ -62,7 +62,7 @@
     "url": "https://github.com/matteobruni/tsparticles/issues"
   },
   "dependencies": {
-    "react-tsparticles": "^1.17.6"
+    "react-tsparticles": "^1.17.7"
   },
   "scripts": {
     "build": "node scripts/prebuild.js",

--- a/templates/react/template.json
+++ b/templates/react/template.json
@@ -1,7 +1,7 @@
 {
   "package": {
     "dependencies": {
-      "react-tsparticles": "^1.17.6"
+      "react-tsparticles": "^1.17.7"
     }
   }
 }


### PR DESCRIPTION
This PR fixes #669, now `grab` mode have `blink` and `consent` properties like the `particles.links` and they work the same way:

`color: "random"` with `consent` and `blink` to `false` (or not set, they default to `false`) will use linked particle color (it's a single particle this time, so the color will be taken from the only particle)

setting`consent` to `true` will have a single random color until `refresh()` or page refresh

setting `blink` to `true` will have a random color each frame having a blinking effect

setting both will take only the `consent`, the `if` comes first