### PR TITLE
Remove "speed" property from bubble mode

### DIFF
--- a/components/angular/README.md
+++ b/components/angular/README.md
@@ -59,8 +59,7 @@ export class AppComponent {
           distance: 400,
           duration: 2,
           opacity: 0.8,
-          size: 40,
-          speed: 3
+          size: 40
         },
         push: {
           quantity: 4

--- a/components/inferno/README.md
+++ b/components/inferno/README.md
@@ -57,8 +57,7 @@ class App extends Component {
                 distance: 400,
                 duration: 2,
                 opacity: 0.8,
-                size: 40,
-                speed: 3,
+                size: 40
               },
               push: {
                 quantity: 4,

--- a/components/jquery/README.md
+++ b/components/jquery/README.md
@@ -61,8 +61,7 @@ $("#tsparticles")
             distance: 400,
             duration: 2,
             opacity: 0.8,
-            size: 40,
-            speed: 3,
+            size: 40
           },
           push: {
             quantity: 4,

--- a/components/preact/README.md
+++ b/components/preact/README.md
@@ -57,8 +57,7 @@ class App extends Component {
                 distance: 400,
                 duration: 2,
                 opacity: 0.8,
-                size: 40,
-                speed: 3,
+                size: 40
               },
               push: {
                 quantity: 4,

--- a/components/vue/README.md
+++ b/components/vue/README.md
@@ -52,8 +52,7 @@ Vue.use(Particles);
                         distance: 400,
                         duration: 2,
                         opacity: 0.8,
-                        size: 40,
-                        speed: 3
+                        size: 40
                     },
                     push: {
                         quantity: 4

--- a/components/vue3/README.md
+++ b/components/vue3/README.md
@@ -52,8 +52,7 @@ createApp(App).use(Particles)
                         distance: 400,
                         duration: 2,
                         opacity: 0.8,
-                        size: 40,
-                        speed: 3
+                        size: 40
                     },
                     push: {
                         quantity: 4


### PR DESCRIPTION
The bubble mode interface is defined as:

```ts
export interface IBubbleBase {
    distance: number;
    duration: number;
    opacity?: number;
    size?: number;
    color?: SingleOrMultiple<IColor | string>;
}
```

but some of the example particle options in the README files were also containing a `speed` property in the bubble object.