### PR TITLE
Spanish translation of main readme and some docs

### DIFF
--- a/core/main/traduction/README.es.md
+++ b/core/main/traduction/README.es.md
@@ -1,0 +1,368 @@
+[![banner](https://cdn.matteobruni.it/images/particles/banner2.png)](https://particles.matteobruni.it)
+
+# tsParticles - TypeScript Particles
+
+**Una biblioteca ligera hecha en TypeScript para crear partículas. ¡Libre de dependencias ([\*](#dependencias)) y lista para usarse en el navegador!**
+
+_[Particles.js](https://github.com/VincentGarreau/particles.js) portado a TypeScript, sin dependencias ([\*](#dependencias)), mejorado con nuevas e increíbles 😎 características. ¡Varios errores han sido resueltos y **en constante mantenimiento**!_
+
+[![jsDelivr](https://data.jsdelivr.com/v1/package/npm/tsparticles/badge?style=rounded)](https://www.jsdelivr.com/package/npm/tsparticles) [![Cdnjs](https://img.shields.io/cdnjs/v/tsparticles)](https://cdnjs.com/libraries/tsparticles) [![npmjs](https://badge.fury.io/js/tsparticles.svg)](https://www.npmjs.com/package/tsparticles) [![npm](https://img.shields.io/npm/dm/tsparticles)](https://www.npmjs.com/package/tsparticles) [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org/) [![CodeFactor](https://www.codefactor.io/repository/github/matteobruni/tsparticles/badge)](https://www.codefactor.io/repository/github/matteobruni/tsparticles) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/b983aaf3461a4c48b1e2eecce1ff1d74)](https://www.codacy.com/manual/ar3s/tsparticles?utm_source=github.com&utm_medium=referral&utm_content=matteobruni/tsparticles&utm_campaign=Badge_Grade) [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/matteobruni/tsparticles)
+
+## ¿Quieres usarlo en tu sitio web?
+
+**Esta biblioteca está disponible a través de dos de los CDNs más populares, haciendo sencillo su uso. Si usaras particles.js sería incluso aún más fácil.**
+
+Podrás encontrar las instrucciones [más abajo](#instalación), con todos los enlaces que necesitas. Recuerda, _no dejes que **TypeScript** te intimide, es solo el lenguaje del código fuente_.
+
+**Los archivos de salida son simplemente JavaScript**. 🤩
+
+Los CNDs y `npm` tienen todos los archivos que necesitas en **JavaScript**, así como un archivo con todo incluido listo para usarse en el navegador (tsparticles.min.js) y todos los archivos separados por la sintáxis `import`.
+
+**Si aún estás interesado**, unas líneas más abajo encontrarás instrucciones para migrar desde la anterior biblioteca particles.js.
+
+## **_Instalación_**
+
+### **_Hosting / CDN_**
+
+**_Por favor, utiliza las siguientes fuentes, o tu propio servidor para cargar tsParticles en tus proyectos._**
+
+#### jsDelivr
+
+[![jsDelivr](https://data.jsdelivr.com/v1/package/npm/tsparticles/badge)](https://www.jsdelivr.com/package/npm/tsparticles)
+
+#### cdnjs
+
+[![Cdnjs](https://img.shields.io/cdnjs/v/tsparticles)](https://cdnjs.com/libraries/tsparticles)
+
+#### unpkg
+
+<https://unpkg.com/tsparticles/>
+
+---
+
+### **_npm_**
+
+[![npmjs](https://badge.fury.io/js/tsparticles.svg)](https://www.npmjs.com/package/tsparticles) [![npmjs](https://img.shields.io/npm/dt/tsparticles)](https://www.npmjs.com/package/tsparticles)
+
+```shell
+npm install tsparticles
+```
+
+### **_yarn_**
+
+```shell
+yarn add tsparticles
+```
+
+#### Import y require
+
+A partir de la versión 1.12.11, puedes utilizar `import` y `require` para importar `tsParticles`.
+
+Ahora, puedes escribir algo como esto
+
+```javascript
+const tsParticles = require("tsparticles");
+
+// o
+
+import { tsParticles } from "tsparticles";
+```
+
+Al importar `tsParticles `, esa es la misma instancia que tienes al incluir el script.
+
+---
+
+### **_NuGet_**
+
+[![Nuget](https://img.shields.io/nuget/v/tsParticles)](https://www.nuget.org/packages/tsParticles/)
+
+---
+
+### **_Uso_**
+
+Carga tsParticles y configura las partículas:
+
+[![tsParticles demo](https://media.giphy.com/media/ftHwBpp3b0qNyCXRuu/giphy.gif)](https://particles.matteobruni.it)
+
+**index.html**
+
+```html
+<div id="tsparticles"></div>
+
+<script src="tsparticles.min.js"></script>
+```
+
+**app.js**
+
+```javascript
+// @path-json puede ser un objeto o un arreglo, el primero va a cargarse directamente, el objeto en el arreglo va a ser elegido al azar.
+/* tsParticles.loadJSON(@dom-id, @path-json, @callback (optional)); */
+
+tsParticles
+  .loadJSON("tsparticles", "presets/default.json")
+  .then((container) => {
+    console.log("callback - configuración de tsparticles cargada");
+  })
+  .catch((error) => {
+    console.error(error);
+  });
+
+//or
+
+/* tsParticles.load(@dom-id, @options); */
+
+tsParticles.load("tsparticles", {
+  /* aquí escribe las opciones */
+});
+
+//or
+
+/* tsParticles.loadFromArray(@dom-id, @options, @index (optional)); */
+
+tsParticles.loadFromArray("tsparticles", [
+  {
+    /* aquí escribe las opciones */
+  },
+  {
+    /* otras opciones aquí */
+  },
+]);
+//objeto al azar
+
+tsParticles.loadFromArray(
+  "tsparticles",
+  [
+    {
+      /* aquí escribe las opciones */
+    },
+    {
+      /* otras opciones aquí */
+    },
+  ],
+  1
+); //el segundo
+// ¡Importante! Si el índice no se encuentra en el rango 0...<array.length, el índice va a ser ignorado.
+
+// Esto se puede utilizar tras la inicialización.
+
+/* tsParticles.setOnClickHandler(@callback); */
+
+/* esto va a ejecutarse desde todas las partículas cargadas */
+
+tsParticles.setOnClickHandler((event, particles) => {
+  /* manejador para el evento al hacer click */
+});
+
+// ahora también es posible controlar las animaciones. Podemos pausar y continuar las
+// animaciones. Estos métodos no cambian la configuración, por lo que tus configuraciones
+// están seguras.
+// domItem(0) regresa la primera instancia de tsParticles que ha sido cargada en el dom.
+const particles = tsParticles.domItem(0);
+
+// play va a comenzar las animaciones. Si el movimiento no está permitido, no lo va a permitir, solo actualiza el fotograma.
+particles.play();
+
+// pause va a detener las animaciones.
+particles.pause();
+```
+
+---
+
+## Componentes oficiales para los frameworks más populares
+
+### Angular
+
+#### `ng-particles`
+
+[![npm](https://img.shields.io/npm/v/ng-particles)](https://www.npmjs.com/package/ng-particles) [![npm](https://img.shields.io/npm/dm/ng-particles)](https://www.npmjs.com/package/ng-particles)
+
+Puedes encontrar las instrucciones [aquí](https://github.com/matteobruni/tsparticles/blob/master/components/angular/README.md)
+
+### Inferno
+
+#### `inferno-particles`
+
+[![npm](https://img.shields.io/npm/v/inferno-particles)](https://www.npmjs.com/package/inferno-particles) [![npm](https://img.shields.io/npm/dm/inferno-particles)](https://www.npmjs.com/package/inferno-particles)
+
+Puedes encontrar las instrucciones [aquí](https://github.com/matteobruni/tsparticles/blob/master/components/inferno/README.md)
+
+### jQuery
+
+#### `jquery-particles`
+
+[![npm](https://img.shields.io/npm/v/jquery-particles)](https://www.npmjs.com/package/jquery-particles) [![npm](https://img.shields.io/npm/dm/jquery-particles)](https://www.npmjs.com/package/jquery-particles)
+
+Puedes encontrar las instrucciones [aquí](https://github.com/matteobruni/tsparticles/blob/master/components/jquery/README.md)
+
+### Preact
+
+#### `preact-particles`
+
+[![npm](https://img.shields.io/npm/v/preact-particles)](https://www.npmjs.com/package/preact-particles) [![npm](https://img.shields.io/npm/dm/preact-particles)](https://www.npmjs.com/package/preact-particles)
+
+Puedes encontrar las instrucciones [aquí](https://github.com/matteobruni/tsparticles/blob/master/components/preact/README.md)
+
+### ReactJS
+
+#### `react-tsparticles`
+
+[![npm](https://img.shields.io/npm/v/react-tsparticles)](https://www.npmjs.com/package/react-tsparticles) [![npm](https://img.shields.io/npm/dm/react-tsparticles)](https://www.npmjs.com/package/react-tsparticles)
+
+Puedes encontrar las instrucciones [aquí](https://github.com/matteobruni/tsparticles/blob/master/components/react/README.md)
+
+### Svelte
+
+#### `svelte-particles`
+
+[![npm](https://img.shields.io/npm/v/svelte-particles)](https://www.npmjs.com/package/svelte-particles) [![npm downloads](https://img.shields.io/npm/dm/svelte-particles)](https://www.npmjs.com/package/svelte-particles)
+
+Puedes encontrar las instrucciones [aquí](https://github.com/matteobruni/tsparticles/blob/master/components/svelte/README.md)
+
+### VueJS
+
+#### `particles.vue`
+
+[![npm](https://img.shields.io/npm/v/particles.vue)](https://www.npmjs.com/package/particles.vue) [![npm](https://img.shields.io/npm/dm/particles.vue)](https://www.npmjs.com/package/particles.vue)
+
+Puedes encontrar las instrucciones [aquí](https://github.com/matteobruni/tsparticles/blob/master/components/vue/README.md)
+
+---
+
+## Plantillas y Recursos
+
+Puedes encontrar algunas plantillas que incorporan tsParticles [aquí](https://github.com/tsparticles/templates). Las plantillas están creadas en *Vanilla JavaScript*, *ReactJS*, *VueJS*, *Angular*, *SvelteJS* y otros frameworks.
+
+Las plantillas pueden variar, pueden crearse nuevas o haber actualizaciones para antiguas, incorporando nuevas características o mejores estilos. Revísalas de vez en cuando.
+
+Si creaste un buen diseño que utiliza *tsParticles*, siéntete libre de enviar un pull request con tu increíble plantilla, ¡se te dará reconocimiento por tu autoría!
+
+<https://github.com/tsparticles/templates>
+
+---
+
+## **_Demo / Generador_**
+
+<https://particles.matteobruni.it/Samples>
+
+[![Demo de partículas](https://particles.matteobruni.it/images/demo.png?v=1.8.1)](https://particles.matteobruni.it/Samples)
+
+---
+
+### Caracteres como partículas
+
+[![Demo de letras como partículas](https://media.giphy.com/media/JsssOXz72bM6jGEZ0s/giphy.gif)](https://particles.matteobruni.it/Samples#chars)
+
+---
+
+### Conecciones al pasar el mouse
+
+[![Demo de conecciones con el mouse](https://media.giphy.com/media/XzvZThpVbxHxMYz5xt/giphy.gif)](https://particles.matteobruni.it/Samples#connect)
+
+---
+
+### Máscara poligonal
+
+[![Demo de máscara poligonal](https://media.giphy.com/media/lNRfiSgaMFbL4FMhW6/giphy.gif)](https://particles.matteobruni.it/Samples#polygonMask)
+
+---
+
+### Estrellas animadas
+
+[![Demo de partículas NASA](https://media.giphy.com/media/cLqGsnh7FKRVMgPIWE/giphy.gif)](https://particles.matteobruni.it/Samples#nasa)
+
+---
+
+### Nyan cat volando a través de estrellas desplazándose
+
+[![Demo de partículas con Nyan cat](https://media.giphy.com/media/LpX2oNc9ZMgIhIXQL9/giphy.gif)](https://particles.matteobruni.it/Samples#nyancat2)
+
+---
+
+### Partículas de nieve
+
+[![Demo de partículas de nieve](https://media.giphy.com/media/gihwUFbmiubbkdzEMX/giphy.gif)](https://particles.matteobruni.it/Samples#snow)
+
+---
+
+### Partículas como máscara para el fondo
+
+[![Demo de máscara del fondo](https://media.giphy.com/media/dWraWgqInWFGWiOyRu/giphy.gif)](https://particles.matteobruni.it/Samples#background)
+
+---
+
+#### Partículas de COVID-19 SARS-CoV-2
+
+[![Demo de partículas COVID-19](https://media.giphy.com/media/fsVN1ZHksgBIXNIbr1/giphy.gif)](https://particles.matteobruni.it/Samples#virus)
+
+_¡No hagas click! ¡NO HAGAS CLICK! OH NO ¡¡¡SE ESPARCE!!!_
+
+**COVID-19 es una enfermedad de seriedad. Por favor, ¡quédate en casa, utiliza mascarilla y mantente seguro!**
+
+---
+
+**particles.json**
+
+Puedes encontrar un ejemplo de configuración [aquí](https://github.com/matteobruni/tsparticles/wiki/tsParticles-Sample-Config) 📖
+
+---
+
+## **_Opciones_**
+
+Puedes encontrar todas las opciones disponibles [aquí](https://particles.js.org/interfaces/_options_interfaces_ioptions_.ioptions.html) 📖
+
+## ¿Quieres verlo en acción y probarlo?
+
+He creado una colección de tsParticles en [CodePen](https://codepen.io/collection/DPOage) 😮 o puedes revisar mi [perfil](https://codepen.io/matteobruni)
+
+Si no, hay una página de demostración en el enlace debajo. Solo da click/toca el Coronavirus debajo, sin miedo. **Es seguro** 😷.
+
+[![Demo tsParticles](https://media.giphy.com/media/fsVN1ZHksgBIXNIbr1/giphy.gif)](https://particles.matteobruni.it/#virus)
+
+¿Quieres ver aún más demostraciones? Clona el repositorio en tu computadora y sigue estas instrucciones
+
+```shell
+yarn install && yarn start
+```
+
+**¡Boom! 💥** <http://localhost:3000> para ver más demostraciones.
+
+_Si eres lo suficientemente valiente_ puedes moverte a la rama `dev` para probar nuevas características que aún están en desarrollo.
+
+## Dependencias
+
+Puedes haber notado el \* al lado de "libre de dependencias". Pues casi todas las características funcionan si alguna dependencia, pero... Hay una pequeña excepción. La **Máscara Poligonal** requiere [`pathseg`](https://github.com/progers/pathseg) para funcionar apropiadamente en algunos navegadores, y obviamente la fuente para íconos (como `FontAwesome`) debe estar incluida en tu página.
+
+---
+
+## Migración desde Particles.js
+
+La biblioteca **tsParticles** es completamente compatible con la configuración de _particles.js_.
+
+En serio, sólo necesitas cambiar el archivo fuente y voilà, **está listo** 🧙!
+
+Puedes leer más al respecto **[aquí](https://dev.to/matteobruni/migrating-from-particles-js-to-tsparticles-2a6m)**
+
+¿Quieres saber 5 razones para hacer el cambio? [Leé aquí](https://dev.to/matteobruni/5-reasons-to-use-tsparticles-and-not-particles-js-1gbe)
+
+_Debajo puedes encontrar toda la información que necesitas para instalar tsParticles y su nueva sintáxis._
+
+---
+
+## Plugins/Personalización
+
+tsParticles ahora soporta personalizaciones 🥳.
+
+**Puedes crear tus propios plugins**
+
+_Leé más [aquí](https://particles.js.org/modules/_core_interfaces_iplugin_.html)..._
+
+---
+
+### Documentación de la API
+
+Documentación y referencias del Desarrollo [aquí](https://particles.matteobruni.it/docs/) 📖
+
+---
+
+[![Slack](https://cdn.matteobruni.it/images/slack.png)](https://join.slack.com/t/tsparticles/shared_invite/enQtOTcxNTQxNjQ4NzkxLWE2MTZhZWExMWRmOWI5MTMxNjczOGE1Yjk0MjViYjdkYTUzODM3OTc5MGQ5MjFlODc4MzE0N2Q1OWQxZDc1YzI) [![tsParticles Product Hunt](https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=186113&theme=light)](https://www.producthunt.com/posts/tsparticles?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-tsparticles")
+

--- a/core/main/traduction/markdown/Color.md
+++ b/core/main/traduction/markdown/Color.md
@@ -1,0 +1,102 @@
+# Colores
+
+Los colores de **tsParticles** pueden tener una variedad de valores y todas las propiedades de color (excepto {@link IParticles.color | particles color}) en las opciones, aceptan todos estos valores.
+
+Todas las propiedades `color` aceptan `string`s y `object`s. El color `object` tiene una única propiedad: `value`.
+
+Exploremos todos los valores válidos.
+
+## Strings
+
+### hex (sintáxis corta
+
+```javascript
+color: '#fff'
+```
+
+### hex (sintáxis completa)
+
+```javascript
+color: '#ffffff'
+```
+
+### Sintáxis rgb
+
+*alpha será ignorado, la propiedad `opacity` está para eso*
+
+```javascript
+color: 'rgb(255, 255, 255)'
+```
+
+### Sintáxis hsl
+
+*alpha será ignorado, la propiedad `opacity` está para eso*
+
+```javascript
+color: 'hsl(0, 100%, 100%)'
+```
+
+### Aleatorio
+
+```javascript
+random: 'random' // se elegirá un color aleatorio
+```
+
+Esa es la parte sencilla, ahora vamos un poco más profundo.
+
+---
+
+## Objeto Color
+
+### strings, de nuevo
+
+```javascript
+color: {
+  value: '#fff' // No repetiré lo que ya dije, todos los valores string de antes son válidos aquí también
+}
+```
+
+### Objeto rgb
+
+```javascript
+color: {
+  value: {
+    r: 255,
+    g: 255,
+    b: 255
+  }
+}
+```
+
+### Objeto hsl
+
+```javascript
+color: {
+  value: {
+    h: 0,
+    s: 100,
+    l: 100
+  }
+}
+```
+
+### Objeto rgb/hsl anidado
+
+```javascript
+color: {
+  value: {
+    rgb: { r: 255, g: 255, b: 255 } // en línea, por brevedad. Es el mismo objeto rgb de antes
+    hsl: { h: 0, s: 100, l: 100 } // en línea, por brevedad. Es el mismo objeto hsl de antes
+  }
+}
+```
+
+*si definimos las propiedades `rgb` y `hsl` al mismo tiempo, solo se usará `rgb`.*
+
+---
+
+## Múltiples colores
+
+Toda propiedad `color.value` acepta un arreglo heterogéneo de sus valores, pero ten cuidado: el color será elegido aleatoriamente.
+
+Para algunos objetos, este comportamiento será adecuado. Otros objetos, como `links` se generan en tiempo de ejecución y tendrán distintos colores en cada fotograma.

--- a/core/main/traduction/markdown/Container.md
+++ b/core/main/traduction/markdown/Container.md
@@ -1,0 +1,28 @@
+# Contenedor de Partículas
+
+La clase {@link Container} es el manejador de la instancia entera tsParticles. Si obtienes un resultado de {@link MainSlim.load | tsParticles.load} el resultado es esta clase. En {@link MainSlim.loadJSON | tsParticles.loadJSON} es el parámetro `then`.
+
+De otro modo, puedes obtener cualquier instancia cargada utilizando {@link MainSlim.dom | tsParticles.dom()} o {@link MainSlim.domItem | tsParticles.domItem(index)}.
+
+## Propiedades
+
+{@link id}: el id de {@link Container}, generalmente es el elemento del DOM relacionado al atributo {@link id}. Se define por {@link MainSlim.load | tsParticles.load()} y {@link MainSlim.loadJSON | tsParticles.loadJSON()}.
+
+{@link options}: Donde se encuentran las opciones actualmente cargadas. Cambiar estas opciones durante la reproducción puede resultar en comportamientos indefinidos. Usar {@link refresh | refresh()} después de un cambio es lo más adecuado.<br />
+{@link sourceOptions}: Las opciones utilizadas cuando se creó el {@link Container}, estas opciones sólo se usarán en el constructor.
+
+{@link particles}: El manejador de las partículas, desde aquí puedes agregar/eliminar partículas.
+
+## Métodos
+
+{@link play | play()}: Se usa para continuar las animaciones, puede detenerse usando {@link pause | pause()}.<br />
+{@link pause | pause()}: Usado para pausar animaciones, puede ser reiniciado con {@link play | play()}.
+
+{@link destroy | destroy()}: Prepara la instancia para su destrucción, no podrás recuperar esta instancia más adelante. Solo si tienes una variable que la referencía.
+
+{@link exportImage | exportImage(callback, type?, quality?)}: Exporta una imagen del canvas (sin la propiedad del fondo, si está definida), `type` y `quality` son opcionales y son el tipo de imagen de salida y calidad.<br />
+{@link exportConfiguration | exportConfiguration()}: Exporta la configuración actual usando JSON, regresa un string.
+
+{@link start | start()}: Inicia el contenedor, difiere de {@link play | play()}, pues esto reiniciará todo.<br />
+{@link stop | stop()}: Detiene el contenedor, difiere de {@link pause | pause()}, pues va a limpiar todo lo que debe ser reiniciado.<br />
+{@link refresh | refresh()}: Reinicia el contenedor, solo es un atajo para {@link stop | stop()}/{@link start | start()}.

--- a/core/main/traduction/markdown/Options.md
+++ b/core/main/traduction/markdown/Options.md
@@ -1,0 +1,23 @@
+# **_Opciones_**
+
+| propiedad         | tipo        | ejemplo                                | notas                                                                                                                                                                                                  |
+| ---------------- | ------------------ | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `background`     | `object`           |                                        | Ver las opciones del Fondo {@link IBackground | aquí}                                                                                                                                                      |
+| `backgroundMask` | `object`           |                                        | Ver las opciones de Máscara del fondo {@link IBackgroundMask | aquí}                                                                                                                                             |
+| `detectRetina`   | `boolean`          | `true` / `false`                       | reemplaza la antigua propiedad `retina_detect`                                                                                                                                                              |
+| `fpsLimit`       | `number`           | `30`                                   | _por defecto es `30`_, reemplaza la antigua propiedad `fps_limit`                                                                                                                                              |
+| `infection`      | `object`           |                                        | Ver las opciones de Infección {@link IInfection | aquí}                                                                                                                                                        |
+| `interactivity`  | `object`           |                                        | Ver las opciones de Interactividad {@link IInteractivity | aquí}                                                                                                                                                |
+| `particles`      | `object`           |                                        | Ver las opciones de Partículas {@link IParticles | aquí}                                                                                                                                                        |
+| `pauseOnBlur`    | `boolean`          | `true` / `false`                       | pausa las animaciones cuando la página está en segundo plano                                                                                                                                                |
+| `preset`         | `string` / `array` | `"basic"`<br /> `[ "basic", "60fps" ]` | Puede usar esta propiedad para cargar uno o más ajustes predefinidos para enfocar propiedades importantes y no toda la configuración. Puedes encontrar ajustes predefinidos en `npm` [here](https://www.npmjs.com/search?q=tsparticles-preset) |
+
+## Plugins
+
+Estas opciones no se usan en el archivo distribuido reducido
+
+| property      | option type        | example | notes                                              |
+| ------------- | ------------------ | ------- | -------------------------------------------------- |
+| `absorbers`   | `object` / `array` |         | Ver las opciones del Absorbente {@link IAbsorber | aquí}     |
+| `emitters`    | `object` / `array` |         | Ver las opciones del Emisor {@link IEmitter | aquí}        |
+| `polygonMask` | `object`           |         | Ver las opciones de Partículas {@link IPolygonMask | aquí}  |

--- a/core/main/traduction/markdown/Plugins.md
+++ b/core/main/traduction/markdown/Plugins.md
@@ -1,0 +1,181 @@
+# Plugins/Personalizaciones
+
+tsParticles ahora soporta personalizaciones 🥳.
+
+**AHORA PUEDES CREAR TUS PROPIAS FIGURAS O AJUSTES PREDEFINIDOS**
+
+## Crear una figura personalizada
+
+Ahora puedes crear un script con tu propia figura para usarla en tu sitio web o para distribuir. Todo lo que debes hacer es una función que dibuje, darle un nombre y usarla en la configuración.
+
+Publica tus figuras con la etiqueta `tsparticles-shape` en `NPM` para que todos lo puedan encontrar.
+
+Encontrarás un ejemplo más abajo.
+
+### Espiral de ejemplo
+
+_spiral.js_ - El script de tu figura personalizada, puedes distribuirla o reutilizarla en todos tus sitios web.
+
+```javascript
+// llama este método antes de inicializar tsParticles, esta figura estará disponible en todas las instancias de tsParticles
+// parámetros: nombre de la figura, método de dibujo
+// la opacidad es solo para figuras que necesitan un manejo de la opacidad distinto, como imágenes
+tsParticles.addShape("spiral", function (context, particle, radius, opacity) {
+  const shapeData = particle.shapeData;
+  const realWidth = (radius - shapeData.innerRadius) / shapeData.lineSpacing;
+
+  for (let i = 0; i < realWidth * 10; i++) {
+    const angle = 0.1 * i;
+    const x =
+      (shapeData.innerRadius + shapeData.lineSpacing * angle) * Math.cos(angle);
+    const y =
+      (shapeData.innerRadius + shapeData.lineSpacing * angle) * Math.sin(angle);
+
+    context.lineTo(x, y);
+  }
+});
+```
+
+Si prefieres utilizar clases, lo puedes hacer. La interfaz {@link IShapeDrawer} puede ser implementada en tu código o al menos una clase con cuatro métodos {@link IShapeDrawer.draw |draw(context, particle, radius, opacity, delta)}, {@link IShapeDrawer.init | init(container)}, {@link IShapeDrawer.afterEffect | afterEffect(context, particle, radius, opacity, delta)}, {@link IShapeDrawer.destroy | destroy(container)} en ella. Puedes encontrar un ejemplo debajo.
+
+```javascript
+class SpiralDrawer {
+  draw(context, particle, radius, opacity, delta) {
+    const shapeData = particle.shapeData;
+    const realWidth = (radius - shapeData.innerRadius) / shapeData.lineSpacing;
+
+    for (let i = 0; i < realWidth * 10; i++) {
+      const angle = 0.1 * i;
+      const x =
+        (shapeData.innerRadius + shapeData.lineSpacing * angle) *
+        Math.cos(angle);
+      const y =
+        (shapeData.innerRadius + shapeData.lineSpacing * angle) *
+        Math.sin(angle);
+
+      context.lineTo(x, y);
+    }
+  }
+}
+
+// llama este método antes de inicializar tsParticles, esta figura estará disponible en todas las instancias de tsParticles
+// parámetros: nombre de la figura, clase para dibujar
+tsParticles.addShape("spiral", new SpiralDrawer());
+```
+
+#### Burbuja de ejemplo (con efecto posterior)
+
+_bubble.js_ - El script para la figura personalizada
+
+```javascript
+tsParticles.addShape(
+    "bubble",
+    function (context, particle, radius) { // función que dibuja
+        context.arc(0, 0, radius, 0, Math.PI * 2, false);
+    },
+    undefined, // no se requiere la función init
+    function (context, particle, radius) { // función para el ejemplo posterior
+        context.save();
+        context.beginPath();
+        context.arc(radius / 3, -radius / 3, radius / 3, 0, Math.PI * 2, false);
+        context.closePath();
+        context.fillStyle = "#fff9";
+        context.fill();
+        context.restore();
+    }
+);
+```
+
+### Configuración
+
+_config.json_ - La sección de configuración para añadir tu configuración o en el readme de tu plugin para enseñar a otros cómo usarlo.
+
+```javascript
+{
+  // [... omitido para ser breves]
+  "particles": {
+    // [... omitido para ser breves]
+    "shape": {
+      "type": "spiral", // esto debe concordar con el nombre anterior, el tipo funciona como siempre, puedes usar un arreglo con tu figura personalizada en él
+      "custom": {
+        // esto debe concordar con el nombre anterior, estos son valores definidos en particle.shapeData (la primera línea del método anterior)
+        // puedes usar arreglos como valores aquí también, los valores se tomarán aleatoriamente, como en figuras estándar
+        "spiral": {
+          "innerRadius": 1,
+          "lineSpacing": 1,
+          "close": false, // este valor es usado en tsParticles para cerrar el trazo, si no quieres cerrarlo, pon este valor en false
+          "fill": false // este valor es usado en tsParticles para rellenar la figura con el color de las partículas, si solo quieres el trazo, pon este valor en false
+        }
+      }
+      // [... omitido para ser breves]
+    }
+    // [... omitido para ser breves]
+  }
+  // [... omitido para ser breves]
+}
+```
+
+## Creando un ajuste predefinido personalizado
+
+Ahora puedes crear un script con tu propio ajuste predefinido para usar en tu sitio web o para su distribución. Todo lo que tienes que hacer es darle un nombre y definir todas las opciones que necesitas para que carge correctamente. Recuerda no importar toda la configuración, las propiedades no necesarias pueden omitirse.
+
+Publica tus ajustes predefinidos con la etiqueta `tsparticles-preset` en `NPM` para que todos lo puedan encontrar.
+
+Encontrarás un ejemplo debajo.
+
+### Ejemplo de ajustes predefinidos de Fuego
+
+_fire.preset.js_ - El script con ajustes predefinidos, puedes distribuirlo o usarlo en todos tus sitios web.
+
+```javascript
+// llama este método antes de inicializar tsParticles, esta figura estará disponible en todas las instancias de tsParticles
+// parámetros: nombre de los ajustes, opciones parciales del ajuste
+tsParticles.addPreset("fire", {
+  fpsLimit: 40,
+  particles: {
+    number: {
+      value: 80,
+      density: {
+        enable: true,
+        value_area: 800,
+      },
+    },
+    color: {
+      value: ["#fdcf58", "#757676", "#f27d0c", "#800909", "#f07f13"],
+    },
+    opacity: {
+      value: 0.5,
+      random: true,
+    },
+    size: {
+      value: 3,
+      random: true,
+    },
+    move: {
+      enable: true,
+      speed: 6,
+      random: false,
+    },
+  },
+  interactivity: {
+    events: {
+      onclick: {
+        enable: true,
+        mode: "push",
+      },
+      resize: true,
+    },
+  },
+  background: {
+    image: "radial-gradient(#4a0000, #000)",
+  },
+});
+```
+
+_config.json_ - La sección de configuración para agregar en tu configuración o en el readme de tu plugin, para enseñar a otros cómo usarlo.
+
+```javascript
+{
+  "preset": "fire" // esto debe concordar con el nombre anterior, puede usarse en valores de un arreglo también, va a cargarse en orden como todo lo demás
+}
+```

--- a/core/main/traduction/markdown/pjsMigration.md
+++ b/core/main/traduction/markdown/pjsMigration.md
@@ -1,0 +1,100 @@
+# Migración desde Particles.js
+
+tsParticles es completamente compatible con Particles.js y la migración es realmente sencilla de realizar.
+
+Revisemos un posible código HTML.
+
+## Solución sencilla
+
+Debes tener algo como el siguiente código
+
+```html
+<script src="particles.min.js"></script>
+```
+
+Para migrar desde particles.js a tsParticles todo lo que debes hacer es reemplazar lo anterior, a esto:
+
+```html
+<script src="tsparticles.min.js"></script>
+```
+
+Si has configurado el css de esta forma
+
+```css
+.particles-js-canvas-element {
+    /* your awesome CSS code */
+}
+```
+
+Debes cambiarlo a lo siguiente
+
+```css
+.tsparticles-canvas-element {
+    /* your awesome CSS code */
+}
+```
+
+Y hemos terminado. Sencillo, ¿no?
+
+## Solución avanzada
+
+Probablemente notaste algunas advertencias en la consola. En efecto es sencillo hacer la migración, pero nuevas características requieren nuevas configuraciones y el arreglar algunos defectos puede estropear algunas cosas.
+
+Si no te es familiar JavaScript, no te preocupes. Puedes saltarte esta parte y dejar las advertencias, todo va a funcionar bien.
+
+Si te importan las advertencias en la consola, estás en el lugar correcto.
+
+El identificador de particlesJS ahora está obsoleto. La biblioteca tiene un nuevo nombre, por lo que ha cambiado.
+
+Ahora revisemos el código de JavaScript, debes tener algo como lo siguiente
+
+```javascript
+/* particlesJS.load(@dom-id, @path-json, @callback (optional)); */
+particlesJS.load('particles-js', 'assets/particles.json', function() {
+  console.log('callback - particles.js config loaded');
+});
+```
+
+o algo así
+
+```javascript
+particlesJS('particles-js', { /* aquí van las opciones */ });
+```
+
+Todo lo que debes hacer es utilizar los nuevos identificadores reemplazando la función
+
+`particlesJS()` por `tsParticles.load()`
+
+o la función
+
+`particlesJS.load()` por `tsParticles.loadJSON()`
+
+**Advertencia aquí, `loadJSON` no tiene un tercer parámetro. Si necesitas un callback utiliza la función `then`.**
+
+Sigue siendo muy sencillo.
+
+Hay que convertir el ejemplo provisto antes para entender
+
+```javascript
+/* particlesJS.load(@dom-id, @path-json, @callback (optional)); */
+tsParticles.loadJSON('particles-js', 'assets/particles.json').then(function(p) {
+  // p es el contenedor cargado para ser usado más adelante
+  console.log('callback - configuración de particles.js cargada');
+});
+
+tsParticles.load('particles-js', { /* aquí van las opciones */ });
+```
+
+Pero probablemente notaste que las advertencias siguen ahí. Las opciones también han cambiado, pero como el identificador, esto no es un problema.
+
+## Transformando Opciones
+
+Revisemos la advertencia de opciones. Nos recomiendan cambiar las propiedades antiguas por las nuevas.
+
+Las propiedades cambiadas aún continúan funcionando, pero serán reemplazadas por nuevas características.
+
+Si encuentras una propiedad con un `_` en el nombre, esa propiedad fue renombrada. Podemos tomar la propiedad `line_linked` como un ejemplo. Ahora ha sido renombrada a `lineLinked`.
+
+¡Boom! ¡Otra advertencia se ha ido!
+
+Revisa las advertencias para encontrar todas las propiedades que han sido renombradas.

--- a/traduction/README.es.md
+++ b/traduction/README.es.md
@@ -1,0 +1,19 @@
+---
+
+<p>  
+    <a href="https://www.jetbrains.com/?from=tsParticles">  
+        <img src="https://cdn.matteobruni.it/images/jetbrains-logos/jetbrains-variant-4.png" height="150" alt="JetBrains" />  
+    </a>  
+    <a href="https://www.jetbrains.com/webstorm/?from=tsParticles">  
+        <img src="https://cdn.matteobruni.it/images/jetbrains-logos/webstorm_logos/logo.png" height="150" alt="JetBrains" />  
+    </a>  
+</p>
+
+### ¡Muchas gracias a [JetBrains](https://www.jetbrains.com/?from=tsParticles) por la Licencia Open Source 2020!
+
+[JetBrains WebStorm](https://www.jetbrains.com/webstorm/?from=tsParticles) es usado en el mantenimiento de este proyecto.
+
+### ¡Muchas gracias a [SauceLabs](https://saucelabs.com) por la Licencia Open Source!
+
+<img alt="Testing Powered By SauceLabs" src="https://raw.githubusercontent.com/saucelabs/saucelabs.github.io/publish/images/opensauce/powered-by-saucelabs-badge-red.svg" width="250" />
+


### PR DESCRIPTION
Translated some markdown files to Spanish.
All files in `core/main/markdown/Options` are missing, maybe someone else will want to contribute as well to that.
Relevant issue #895 