### PR TITLE
feat: add z-index option to Particles, renders particles in that order

### DIFF
--- a/core/main/markdown/Options/Particles/ZIndex.md
+++ b/core/main/markdown/Options/Particles/ZIndex.md
@@ -1,8 +1,8 @@
 # Particles zIndex
 
-| key                      | option type          | example          | notes                                                    |
-| ------------------------ | -------------------- | ---------------- | -------------------------------------------------------- |
-| `value`                  | `number`             | `-10000...10000` | Defaults to 0.                                           |
-| `rate_opacity`           | `number`             | `2`              | The rate with which the z-index alters the particle's opacity.                                           |
-| `rate_velocity`          | `number`             | `-10`            | The rate with which the z-index alters the particle's velocity.                                           |
-| `rate_size`              | `number`             | `5`              | The rate with which the z-index alters the particle's size.                                           |
+| key                      | option type          | example          | notes                                                           |
+| ------------------------ | -------------------- | ---------------- | --------------------------------------------------------------- |
+| `value`                  | `number`             | `-10000...10000` | Defaults to 0.                                                  |
+| `rateOpacity`            | `number`             | `2`              | The rate with which the z-index alters the particle's opacity.  |
+| `rateVelocity`           | `number`             | `-10`            | The rate with which the z-index alters the particle's velocity. |
+| `rateSize`               | `number`             | `5`              | The rate with which the z-index alters the particle's size.     |

--- a/core/main/markdown/Options/Particles/ZIndex.md
+++ b/core/main/markdown/Options/Particles/ZIndex.md
@@ -1,0 +1,8 @@
+# Particles zIndex
+
+| key                      | option type          | example          | notes                                                    |
+| ------------------------ | -------------------- | ---------------- | -------------------------------------------------------- |
+| `value`                  | `number`             | `-10000...10000` | Defaults to 0.                                           |
+| `rate_opacity`           | `number`             | `2`              | The rate with which the z-index alters the particle's opacity.                                           |
+| `rate_velocity`          | `number`             | `-10`            | The rate with which the z-index alters the particle's velocity.                                           |
+| `rate_size`              | `number`             | `5`              | The rate with which the z-index alters the particle's size.                                           |

--- a/core/main/src/Core/Particle.ts
+++ b/core/main/src/Core/Particle.ts
@@ -159,9 +159,8 @@ export class Particle implements IParticle {
         this.fill = this.shapeData?.fill ?? this.fill;
         this.close = this.shapeData?.close ?? this.close;
         this.particlesOptions = particlesOptions;
-        this.zIndexFactor = this.particlesOptions.zIndex.value;
         // Scale z-index factor to be between 0 and 2
-        const ClampedZIndexFactor = (this.zIndexFactor + 10000) / 10000;
+        this.zIndexFactor = (this.particlesOptions.zIndex.value + 10000) / 10000;
         this.noiseDelay = NumberUtils.getValue(this.particlesOptions.move.noise.delay) * 1000;
 
         container.retina.initParticle(this);
@@ -172,7 +171,7 @@ export class Particle implements IParticle {
         const sizeOptions = this.particlesOptions.size;
         const sizeValue =
             NumberUtils.getValue(sizeOptions) *
-            (1 + this.particlesOptions.zIndex.size_rate * 0.5 * ClampedZIndexFactor) *
+            (1 + this.particlesOptions.zIndex.sizeRate * 0.5 * this.zIndexFactor) *
             container.retina.pixelRatio;
 
         const randomSize = typeof sizeOptions.random === "boolean" ? sizeOptions.random : sizeOptions.random.enable;
@@ -191,10 +190,10 @@ export class Particle implements IParticle {
         this.velocity = {
             horizontal:
                 this.initialVelocity.horizontal *
-                (1 + this.particlesOptions.zIndex.velocity_rate * (ClampedZIndexFactor - 1)),
+                (1 + this.particlesOptions.zIndex.velocityRate * (this.zIndexFactor - 1)),
             vertical:
                 this.initialVelocity.vertical *
-                (1 + this.particlesOptions.zIndex.velocity_rate * (ClampedZIndexFactor - 1)),
+                (1 + this.particlesOptions.zIndex.velocityRate * (this.zIndexFactor - 1)),
         };
 
         this.pathAngle = Math.atan2(this.initialVelocity.vertical, this.initialVelocity.horizontal);
@@ -309,12 +308,10 @@ export class Particle implements IParticle {
                 : opacityValue,
         };
 
+        // Don't let opacity go below 0 or above 1
         this.opacity.value = Math.max(
             0,
-            Math.min(
-                1,
-                this.opacity.value * (1 + this.particlesOptions.zIndex.opacity_rate * (ClampedZIndexFactor - 1))
-            )
+            Math.min(1, this.opacity.value * (1 + this.particlesOptions.zIndex.opacityRate * (this.zIndexFactor - 1)))
         );
 
         const opacityAnimation = opacityOptions.animation;

--- a/core/main/src/Core/Particle.ts
+++ b/core/main/src/Core/Particle.ts
@@ -159,7 +159,8 @@ export class Particle implements IParticle {
         this.fill = this.shapeData?.fill ?? this.fill;
         this.close = this.shapeData?.close ?? this.close;
         this.particlesOptions = particlesOptions;
-        this.zIndexFactor = (this.particlesOptions.zIndex + 100) / 100;
+        // Scale z-index factor to be between 0 and approximately 2
+        this.zIndexFactor = (this.particlesOptions.zIndex + 10000) / 10000;
         this.noiseDelay = NumberUtils.getValue(this.particlesOptions.move.noise.delay) * 1000;
 
         container.retina.initParticle(this);
@@ -168,7 +169,10 @@ export class Particle implements IParticle {
 
         /* size */
         const sizeOptions = this.particlesOptions.size;
-        const sizeValue = NumberUtils.getValue(sizeOptions) * this.zIndexFactor * container.retina.pixelRatio;
+        // Calculate zIndexSizeFactor, which is used to scale the size and opacity of a particle
+        // The zIndexSizeFactor is a value between 0.5 and 1.5
+        const zIndexSizeFactor = 1.5 - 0.5 * this.zIndexFactor;
+        const sizeValue = NumberUtils.getValue(sizeOptions) * zIndexSizeFactor * container.retina.pixelRatio;
 
         const randomSize = typeof sizeOptions.random === "boolean" ? sizeOptions.random : sizeOptions.random.enable;
 
@@ -300,7 +304,7 @@ export class Particle implements IParticle {
                 : opacityValue,
         };
 
-        this.opacity.value *= this.zIndexFactor;
+        this.opacity.value = Math.max(0, Math.min(1, this.opacity.value * zIndexSizeFactor));
 
         const opacityAnimation = opacityOptions.animation;
 

--- a/core/main/src/Options/Classes/Particles/Particles.ts
+++ b/core/main/src/Options/Classes/Particles/Particles.ts
@@ -17,6 +17,7 @@ import type { IOptionLoader } from "../../Interfaces/IOptionLoader";
 import { Life } from "./Life/Life";
 import { Bounce } from "./Bounce/Bounce";
 import { Utils } from "../../../Utils";
+import { ZIndex } from "./ZIndex/ZIndex";
 
 /**
  * [[include:Options/Particles.md]]
@@ -92,7 +93,7 @@ export class Particles implements IParticles, IOptionLoader<IParticles> {
         this.size = new Size();
         this.stroke = new Stroke();
         this.twinkle = new Twinkle();
-        this.zIndex = 0;
+        this.zIndex = new ZIndex();
     }
 
     public load(data?: RecursivePartial<IParticles>): void {
@@ -100,9 +101,7 @@ export class Particles implements IParticles, IOptionLoader<IParticles> {
             return;
         }
 
-        // Default z-index to 0, and cap it between -9999 and 9999.
-        this.zIndex = data.zIndex || 0;
-        this.zIndex = Math.max(-9999, Math.min(9999, this.zIndex));
+        this.zIndex.load(data.zIndex);
 
         this.bounce.load(data.bounce);
         this.color = AnimatableColor.create(this.color, data.color);

--- a/core/main/src/Options/Classes/Particles/Particles.ts
+++ b/core/main/src/Options/Classes/Particles/Particles.ts
@@ -100,9 +100,9 @@ export class Particles implements IParticles, IOptionLoader<IParticles> {
             return;
         }
 
-        if (data.zIndex !== undefined) {
-            this.zIndex = data.zIndex;
-        }
+        // Default z-index to 0, and cap it between -9999 and 9999.
+        this.zIndex = data.zIndex || 0;
+        this.zIndex = Math.max(-9999, Math.min(9999, this.zIndex));
 
         this.bounce.load(data.bounce);
         this.color = AnimatableColor.create(this.color, data.color);

--- a/core/main/src/Options/Classes/Particles/ZIndex/ZIndex.ts
+++ b/core/main/src/Options/Classes/Particles/ZIndex/ZIndex.ts
@@ -1,0 +1,44 @@
+import type { IZIndex } from "../../../Interfaces/Particles/ZIndex/IZIndex";
+import type { RecursivePartial } from "../../../../Types";
+import type { IOptionLoader } from "../../../Interfaces/IOptionLoader";
+
+/**
+ * @category Options
+ */
+export class ZIndex implements IZIndex, IOptionLoader<IZIndex> {
+    value;
+    opacity_rate;
+    size_rate;
+    velocity_rate;
+
+    constructor() {
+        this.value = 0;
+        this.opacity_rate = 0;
+        this.size_rate = 0;
+        this.velocity_rate = 0;
+    }
+
+    public load(data?: RecursivePartial<IZIndex>): void {
+        if (data === undefined) {
+            return;
+        }
+
+        if (data.value !== undefined) {
+            this.value = data.value;
+            // Cap z-index it between -10000 and 10000.
+            this.value = Math.max(-10000, Math.min(10000, this.value));
+        }
+
+        if (data.opacity_rate !== undefined) {
+            this.opacity_rate = data.opacity_rate;
+        }
+
+        if (data.size_rate !== undefined) {
+            this.size_rate = data.size_rate;
+        }
+
+        if (data.velocity_rate !== undefined) {
+            this.velocity_rate = data.velocity_rate;
+        }
+    }
+}

--- a/core/main/src/Options/Classes/Particles/ZIndex/ZIndex.ts
+++ b/core/main/src/Options/Classes/Particles/ZIndex/ZIndex.ts
@@ -6,16 +6,16 @@ import type { IOptionLoader } from "../../../Interfaces/IOptionLoader";
  * @category Options
  */
 export class ZIndex implements IZIndex, IOptionLoader<IZIndex> {
-    value;
-    opacity_rate;
-    size_rate;
-    velocity_rate;
+    public value;
+    public opacityRate;
+    public sizeRate;
+    public velocityRate;
 
     constructor() {
         this.value = 0;
-        this.opacity_rate = 0;
-        this.size_rate = 0;
-        this.velocity_rate = 0;
+        this.opacityRate = 0;
+        this.sizeRate = 0;
+        this.velocityRate = 0;
     }
 
     public load(data?: RecursivePartial<IZIndex>): void {
@@ -29,16 +29,16 @@ export class ZIndex implements IZIndex, IOptionLoader<IZIndex> {
             this.value = Math.max(-10000, Math.min(10000, this.value));
         }
 
-        if (data.opacity_rate !== undefined) {
-            this.opacity_rate = data.opacity_rate;
+        if (data.opacityRate !== undefined) {
+            this.opacityRate = data.opacityRate;
         }
 
-        if (data.size_rate !== undefined) {
-            this.size_rate = data.size_rate;
+        if (data.sizeRate !== undefined) {
+            this.sizeRate = data.sizeRate;
         }
 
-        if (data.velocity_rate !== undefined) {
-            this.velocity_rate = data.velocity_rate;
+        if (data.velocityRate !== undefined) {
+            this.velocityRate = data.velocityRate;
         }
     }
 }

--- a/core/main/src/Options/Interfaces/Particles/IParticles.ts
+++ b/core/main/src/Options/Interfaces/Particles/IParticles.ts
@@ -13,6 +13,7 @@ import type { ITwinkle } from "./Twinkle/ITwinkle";
 import type { IAnimatableColor } from "./IAnimatableColor";
 import type { ILife } from "./Life/ILife";
 import type { IBounce } from "./Bounce/IBounce";
+import { IZIndex } from "./ZIndex/IZIndex";
 
 /**
  * [[include:Options/Particles.md]]
@@ -45,5 +46,5 @@ export interface IParticles {
     size: ISize;
     stroke: SingleOrMultiple<IStroke>;
     twinkle: ITwinkle;
-    zIndex: number;
+    zIndex: IZIndex;
 }

--- a/core/main/src/Options/Interfaces/Particles/ZIndex/IZIndex.ts
+++ b/core/main/src/Options/Interfaces/Particles/ZIndex/IZIndex.ts
@@ -1,0 +1,10 @@
+/**
+ * @category Options
+ * [[include:ZIndex.md]]
+ */
+export interface IZIndex {
+    value: number;
+    opacity_rate: number;
+    velocity_rate: number;
+    size_rate: number;
+}

--- a/core/main/src/Options/Interfaces/Particles/ZIndex/IZIndex.ts
+++ b/core/main/src/Options/Interfaces/Particles/ZIndex/IZIndex.ts
@@ -4,7 +4,7 @@
  */
 export interface IZIndex {
     value: number;
-    opacity_rate: number;
-    velocity_rate: number;
-    size_rate: number;
+    opacityRate: number;
+    velocityRate: number;
+    sizeRate: number;
 }

--- a/demo/main/public/presets/zIndex.json
+++ b/demo/main/public/presets/zIndex.json
@@ -11,7 +11,7 @@
         },
         "zIndex": {
           "value": 5000,
-          "velocity_rate": 20
+          "velocityRate": 20
         }
       },
       "yellow": {
@@ -34,9 +34,9 @@
         },
         "zIndex": {
           "value": -5000,
-          "velocity_rate": 0,
-          "opacity_rate": 0,
-          "size_rate": 10
+          "velocityRate": 0,
+          "opacityRate": 0,
+          "sizeRate": 10
         }
       },
       "cyan": {

--- a/demo/main/public/presets/zIndex.json
+++ b/demo/main/public/presets/zIndex.json
@@ -9,7 +9,7 @@
         "color": {
           "value": "#00ff00"
         },
-        "zIndex": 50
+        "zIndex": 5000
       },
       "yellow": {
         "number": {
@@ -27,7 +27,7 @@
         "color": {
           "value": "#0000ff"
         },
-        "zIndex": -50
+        "zIndex": -50000
       },
       "cyan": {
         "number": {
@@ -36,7 +36,7 @@
         "color": {
           "value": "#00ffff"
         },
-        "zIndex": 25
+        "zIndex": 0
       }
     },
     "number": {

--- a/demo/main/public/presets/zIndex.json
+++ b/demo/main/public/presets/zIndex.json
@@ -9,7 +9,10 @@
         "color": {
           "value": "#00ff00"
         },
-        "zIndex": 5000
+        "zIndex": {
+          "value": 5000,
+          "velocity_rate": 20
+        }
       },
       "yellow": {
         "number": {
@@ -18,7 +21,9 @@
         "color": {
           "value": "#ffff00"
         },
-        "zIndex": -75
+        "zIndex": {
+          "value": -75
+        }
       },
       "blue": {
         "number": {
@@ -27,7 +32,12 @@
         "color": {
           "value": "#0000ff"
         },
-        "zIndex": -50000
+        "zIndex": {
+          "value": -5000,
+          "velocity_rate": 0,
+          "opacity_rate": 0,
+          "size_rate": 10
+        }
       },
       "cyan": {
         "number": {
@@ -36,7 +46,9 @@
         "color": {
           "value": "#00ffff"
         },
-        "zIndex": 0
+        "zIndex": {
+          "value": 0
+        }
       }
     },
     "number": {


### PR DESCRIPTION
PR according to feature request #979 

The z-index is basically a copy of the opacity option, because a changing z-index could potentially be a cool effect. However, then the particles array needs to be sorted on every draw() call. This didn't affect too much performance on my computer, but laptops (for example) could have an issue with this. The implementation only orders the particles when new particles are added at the moment.