### PR TITLE
change particlesLoaded prop type to be a function

### DIFF
--- a/components/vue3/src/Particles/Particles.vue
+++ b/components/vue3/src/Particles/Particles.vue
@@ -24,7 +24,7 @@ export type IParticlesParams = IParticlesProps;
       type: String
     },
     particlesLoaded: {
-      type: Object as PropType<(container: Container) => void>
+      type: Function as PropType<(container: Container) => void>
     },
     particlesInit: {
       type: Function as PropType<(engine: Engine) => void>


### PR DESCRIPTION
Simple change `particlesLoaded` to be a prop of type function, to prevent some vue warnings.