### PR TITLE
Update Svelte event handling snippets

### DIFF
--- a/components/svelte/README.md
+++ b/components/svelte/README.md
@@ -52,7 +52,9 @@ yarn add svelte-particles
     // (from the core library) methods like play, pause, refresh, start, stop
   };
 
-  let onParticlesInit = (main) => {
+  let onParticlesInit = (event) => {
+    const main = event.detail;
+
     // you can use main to customize the tsParticles instance adding presets or custom shapes
   };
 </script>

--- a/components/svelte/traduction/README.mn.md
+++ b/components/svelte/traduction/README.mn.md
@@ -52,7 +52,9 @@ yarn add svelte-particles svelte
     // (from the core library) methods like play, pause, refresh, start, stop
   };
 
-  let onParticlesInit = (main) => {
+  let onParticlesInit = (event) => {
+    const main = event.detail;
+
     // you can use main to customize the tsParticles instance adding presets or custom shapes
   };
 </script>

--- a/presets/bigCircles/README.md
+++ b/presets/bigCircles/README.md
@@ -138,7 +138,8 @@ function particlesInit(main: Main): void {
 ```
 
 ```js
-let onParticlesInit = (main) => {
+let onParticlesInit = (event) => {
+  const main = event.detail;
   loadBigCirclesPreset(main);
 };
 ```

--- a/presets/bubbles/README.md
+++ b/presets/bubbles/README.md
@@ -141,7 +141,8 @@ function particlesInit(main: Main): void {
 ```
 
 ```js
-let onParticlesInit = (main) => {
+let onParticlesInit = (event) => {
+  const main = event.detail;
   loadBubblesPreset(main);
 };
 ```

--- a/presets/confetti/README.md
+++ b/presets/confetti/README.md
@@ -218,7 +218,8 @@ function particlesInit(main: Main): void {
 ```
 
 ```js
-let onParticlesInit = (main) => {
+let onParticlesInit = (event) => {
+  const main = event.detail;
   loadConfettiPreset(main);
 };
 ```

--- a/presets/fire/README.md
+++ b/presets/fire/README.md
@@ -140,7 +140,8 @@ function particlesInit(main: Main): void {
 ```
 
 ```js
-let onParticlesInit = (main) => {
+let onParticlesInit = (event) => {
+  const main = event.detail;
   loadFirePreset(main);
 };
 ```

--- a/presets/firefly/README.md
+++ b/presets/firefly/README.md
@@ -141,7 +141,8 @@ function particlesInit(main: Main): void {
 ```
 
 ```js
-let onParticlesInit = (main) => {
+let onParticlesInit = (event) => {
+  const main = event.detail;
   loadFireflyPreset(main);
 };
 ```

--- a/presets/fireworks/README.md
+++ b/presets/fireworks/README.md
@@ -140,7 +140,8 @@ function particlesInit(main: Main): void {
 ```
 
 ```js
-let onParticlesInit = (main) => {
+let onParticlesInit = (event) => {
+  const main = event.detail;
   loadFireworksPreset(main);
 };
 ```

--- a/presets/fountain/README.md
+++ b/presets/fountain/README.md
@@ -141,7 +141,8 @@ function particlesInit(main: Main): void {
 ```
 
 ```js
-let onParticlesInit = (main) => {
+let onParticlesInit = (event) => {
+  const main = event.detail;
   loadFountainPreset(main);
 };
 ```

--- a/presets/links/README.md
+++ b/presets/links/README.md
@@ -141,7 +141,8 @@ function particlesInit(main: Main): void {
 ```
 
 ```js
-let onParticlesInit = (main) => {
+let onParticlesInit = (event) => {
+  const main = event.detail;
   loadLinksPreset(main);
 };
 ```

--- a/presets/seaAnemone/README.md
+++ b/presets/seaAnemone/README.md
@@ -141,7 +141,8 @@ function particlesInit(main: Main): void {
 ```
 
 ```js
-let onParticlesInit = (main) => {
+let onParticlesInit = (event) => {
+  const main = event.detail;
   loadSeaAnemonePreset(main);
 };
 ```

--- a/presets/snow/README.md
+++ b/presets/snow/README.md
@@ -140,7 +140,8 @@ function particlesInit(main: Main): void {
 ```
 
 ```js
-let onParticlesInit = (main) => {
+let onParticlesInit = (event) => {
+  const main = event.detail;
   loadSnowPreset(main);
 };
 ```

--- a/presets/stars/README.md
+++ b/presets/stars/README.md
@@ -140,7 +140,8 @@ function particlesInit(main: Main): void {
 ```
 
 ```js
-let onParticlesInit = (main) => {
+let onParticlesInit = (event) => {
+  const main = event.detail;
   loadStarsPreset(main);
 };
 ```

--- a/presets/triangles/README.md
+++ b/presets/triangles/README.md
@@ -141,7 +141,8 @@ function particlesInit(main: Main): void {
 ```
 
 ```js
-let onParticlesInit = (main) => {
+let onParticlesInit = (event) => {
+  const main = event.detail;
   loadTrianglesPreset(main);
 };
 ```


### PR DESCRIPTION
Svelte event callback parameter is a `CustomEvent`, so we need to use `event.detail` to get the engine/container before passing on to other functions.

Please check if I missed some other places, and I'll update it accordingly.