### PR TITLE
Add typings for Svelte component

### DIFF
--- a/components/svelte/package.json
+++ b/components/svelte/package.json
@@ -57,6 +57,7 @@
   "main": "dist/umd/svelte-particles.js",
   "module": "dist/es/svelte-particles.js",
   "svelte": "src/index.ts",
+  "types": "src/index.d.ts",
   "peerDependencies": {
     "svelte": ">=3"
   },

--- a/components/svelte/src/index.d.ts
+++ b/components/svelte/src/index.d.ts
@@ -1,0 +1,21 @@
+import type { SvelteComponentTyped } from "svelte";
+import type { ISourceOptions, Engine, Container } from "tsparticles";
+
+declare module "svelte-particles"
+{
+    type CustomEventWrapper<T> = {
+        [K in keyof T]: CustomEvent<T[K]>;
+    };
+    type ParticlesProps = {
+        options?: ISourceOptions;
+        url?: string;
+        id?: string;
+    };
+    type ParticlesEvents = CustomEventWrapper<{
+        particlesInit: Engine;
+        particlesLoaded: {
+            particles?: Container;
+        };
+    }>;
+    export default class extends SvelteComponentTyped<ParticlesProps, ParticlesEvents, {}> {}
+}


### PR DESCRIPTION
My first code related PR :)

Tested this on my personal project. So far, the `options` prop and the 2 events are typed correctly.
Is there a coding convention (spaces vs. tabs, bracket on same line vs. separate line, etc.) or something I need to follow?