### PR TITLE
Removed useless console.log in Canvas.ts

### DIFF
--- a/engine/src/Core/Canvas.ts
+++ b/engine/src/Core/Canvas.ts
@@ -365,8 +365,6 @@ export class Canvas {
             };
 
             this.coverColorStyle = getStyleFromRgb(coverColor, coverColor.a);
-
-            console.log(this.coverColorStyle);
         }
     }
 


### PR DESCRIPTION
Noticed this console.log spam starting from react-tsparticles v 1.41.0