### PR TITLE
fix: typo in readme for react-tsparticles

### DIFF
--- a/components/react/README.md
+++ b/components/react/README.md
@@ -60,7 +60,7 @@ const App = () => {
     // you can initialize the tsParticles instance (main) here, adding custom shapes or presets
     // this loads the tsparticles package bundle, it's the easiest method for getting everything ready
     // starting from v2 you can add only the features you need reducing the bundle size
-    await loadFull(tsParticles);
+    await loadFull(main);
   };
 
   const particlesLoaded = (container) => {


### PR DESCRIPTION
Fix typo in readme for react-tsparticles. Fixes #4245.