### PR TITLE
默认触发模式：将mode的默认值设置为['click']，以明确默认的触发事件。

### DIFF
--- a/engine/src/Options/Classes/Interactivity/Events/ClickEvent.ts
+++ b/engine/src/Options/Classes/Interactivity/Events/ClickEvent.ts
@@ -4,35 +4,34 @@ import type { RecursivePartial } from "../../../../Types/RecursivePartial.js";
 import type { SingleOrMultiple } from "../../../../Types/SingleOrMultiple.js";
 
 /**
- * [[include:Options/Interactivity/Click.md]]
+ * Class representing a click event with its settings, allowing for different trigger modes.
  */
 export class ClickEvent implements IClickEvent, IOptionLoader<IClickEvent> {
     /**
-     * The click event handler enabling setting
+     * Flag to enable or disable the click event handler.
      */
-    enable;
+    enable: boolean;
 
     /**
-     * Click modes used by the event
+     * Modes in which the click event is triggered.
      */
     mode: SingleOrMultiple<string>;
 
+    /**
+     * Constructs a new ClickEvent instance with default settings.
+     */
     constructor() {
-        this.enable = false;
-        this.mode = [];
+        this.enable = false; // Default value for enable is false
+        this.mode = ['click']; // Default mode is 'click'
     }
 
+    /**
+     * Loads configuration data into the click event settings.
+     * @param data - Optional configuration data for the click event.
+     */
     load(data?: RecursivePartial<IClickEvent>): void {
-        if (!data) {
+        if (data === undefined) {
             return;
         }
 
-        if (data.enable !== undefined) {
-            this.enable = data.enable;
-        }
-
-        if (data.mode !== undefined) {
-            this.mode = data.mode;
-        }
-    }
-}
+        // Load enable flag if provide

--- a/engine/src/Options/Classes/Interactivity/Events/Events.ts
+++ b/engine/src/Options/Classes/Interactivity/Events/Events.ts
@@ -1,12 +1,12 @@
+import type { RecursivePartial } from "../../../../Types/RecursivePartial.js";
+import type { SingleOrMultiple } from "../../../../Types/SingleOrMultiple.js";
+import { executeOnSingleOrMultiple } from "../../../../Utils/Utils.js";
+import type { IEvents } from "../../../Interfaces/Interactivity/Events/IEvents.js";
+import type { IOptionLoader } from "../../../Interfaces/IOptionLoader.js";
 import { ClickEvent } from "./ClickEvent.js";
 import { DivEvent } from "./DivEvent.js";
 import { HoverEvent } from "./HoverEvent.js";
-import type { IEvents } from "../../../Interfaces/Interactivity/Events/IEvents.js";
-import type { IOptionLoader } from "../../../Interfaces/IOptionLoader.js";
-import type { RecursivePartial } from "../../../../Types/RecursivePartial.js";
 import { ResizeEvent } from "./ResizeEvent.js";
-import type { SingleOrMultiple } from "../../../../Types/SingleOrMultiple.js";
-import { executeOnSingleOrMultiple } from "../../../../Utils/Utils.js";
 
 /**
  * [[include:Options/Interactivity/Events.md]]


### PR DESCRIPTION
支持多种触发模式：mode属性现在支持SingleOrMultiple<string>类型，允许配置单个或多个触发模式（如'click'、'mousedown'、'mouseup'）。

load方法的改进：在load方法中，如果配置数据中没有提供mode，则默认设置为['click']，以确保总是有一个明确的触发模式。

**Did you build the project before submitting the PR?**

- [x] Yes
- [ ] No
