### PR TITLE
Fix Vue wrapper declaration entrypoints

### DIFF
--- a/wrappers/vue2/package.dist.json
+++ b/wrappers/vue2/package.dist.json
@@ -81,12 +81,12 @@
     }
   ],
   "prettier": "@tsparticles/prettier-config",
-  "types": "index.d.ts",
+  "types": "src/Particles/index.d.ts",
   "module": "vue2-particles.es.js",
   "main": "vue2-particles.umd.js",
   "exports": {
     ".": {
-      "types": "./index.d.ts",
+      "types": "./src/Particles/index.d.ts",
       "import": "./vue2-particles.es.js",
       "require": "./vue2-particles.umd.js",
       "default": "./vue2-particles.umd.js"

--- a/wrappers/vue2/package.json
+++ b/wrappers/vue2/package.json
@@ -3,10 +3,10 @@
   "version": "4.2.1",
   "main": "dist/vue2-particles.umd.js",
   "module": "dist/vue2-particles.es.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/src/Particles/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/src/Particles/index.d.ts",
       "import": "./dist/vue2-particles.es.js",
       "require": "./dist/vue2-particles.umd.js",
       "default": "./dist/vue2-particles.umd.js"

--- a/wrappers/vue3/package.dist.json
+++ b/wrappers/vue3/package.dist.json
@@ -82,12 +82,12 @@
     }
   ],
   "prettier": "@tsparticles/prettier-config",
-  "types": "index.d.ts",
+  "types": "src/components/index.d.ts",
   "module": "particles.es.js",
   "main": "particles.es.js",
   "exports": {
     ".": {
-      "types": "./index.d.ts",
+      "types": "./src/components/index.d.ts",
       "default": "./particles.es.js"
     }
   },

--- a/wrappers/vue3/package.json
+++ b/wrappers/vue3/package.json
@@ -3,10 +3,10 @@
   "version": "4.2.1",
   "type": "module",
   "main": "dist/particles.es.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/src/components/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/src/components/index.d.ts",
       "default": "./dist/particles.es.js"
     }
   },


### PR DESCRIPTION
## Summary
- Point the published `@tsparticles/vue2` type entrypoints at the shipped `src/Particles/index.d.ts` file.
- Point the published `@tsparticles/vue3` type entrypoints at the shipped `src/components/index.d.ts` file.

## Why
The `4.2.1` packages currently advertise a root `index.d.ts`, but that file is not present in the published tarballs. TypeScript consumers can hit TS7016 even though declaration files are included under `src`.

## Validation
- Clean TypeScript consumer: current `@tsparticles/vue2@4.2.1` reproduces TS7016; the same package contents with the corrected `package.json` passes `tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --strict --skipLibCheck false`.
- Clean TypeScript consumer: current `@tsparticles/vue3@4.2.1` reproduces TS7016; the same package contents with the corrected `package.json` passes `tsc --noEmit --module ESNext --moduleResolution Bundler --target ES2022 --strict --skipLibCheck false`.
